### PR TITLE
feat(types): PEP 695 aliases, union of primitives, recursive JSON aliases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,104 @@
+<!--
+Thanks for contributing to didactic. Fill out each section briefly so
+reviewers can land your change quickly. Keep prose tight; link to
+issues, designs, or upstream docs rather than re-explaining them here.
+-->
+
+## Summary
+
+<!--
+1-3 sentences: what does this PR change, and why? Lead with the user-
+visible effect (a new feature, a bug fix, a docs improvement) before the
+implementation details. Link the issue this resolves with `Closes #N`.
+-->
+
+## Motivation
+
+<!--
+What problem does this solve, and how did it surface? A bug report, a
+user integration, a measurement, a follow-up to a previous PR. If the
+"why" is in an issue, just link it — don't re-state.
+-->
+
+## Changes
+
+<!--
+Bullet list of the substantive changes, organised by package or layer.
+Skip cosmetic edits (formatting, typos) unless they're load-bearing.
+-->
+
+- `packages/didactic/src/...` — ...
+- `packages/didactic-pydantic/...` — ...
+- `docs/...` — ...
+- `tests/...` — ...
+
+## Tests
+
+<!--
+Which tests cover the change, and what cases do they exercise? Note any
+property-based or integration tests added. If you couldn't write a test
+(e.g. it depends on an external service), explain why and what manual
+validation you did instead.
+-->
+
+## Local CI
+
+<!--
+Confirm each gate passed locally. Match the CI matrix exactly so the
+remote run isn't your first signal.
+-->
+
+- [ ] `uv run ruff format --check`
+- [ ] `uv run ruff check`
+- [ ] `uv run pyright`
+- [ ] `uv run pytest -ra`
+- [ ] `uv run mkdocs build --strict`
+
+## Compatibility
+
+<!--
+Pick one. Delete the others.
+-->
+
+- **No user-visible change** — internal refactor, docs, tests, or CI.
+- **Backwards-compatible addition** — new public symbols or new
+  optional parameters; existing code keeps working.
+- **Behaviour change** — existing public API behaves differently; call
+  out the migration path for users.
+- **Breaking change** — existing public API is removed or changes
+  shape; bump the minor version (or major if post-1.0) and document
+  the migration in the changelog.
+
+## Changelog
+
+<!--
+Did you update `CHANGELOG.md`? Place the entry under `[Unreleased]` in
+the appropriate Keep-a-Changelog section (Added / Changed / Deprecated
+/ Removed / Fixed / Security). Link issues with `([#N])`.
+
+If the change is internal (refactor, test, CI, docs), no entry is
+needed; tick "no entry needed" below.
+-->
+
+- [ ] Added a `CHANGELOG.md` entry under `[Unreleased]`.
+- [ ] No changelog entry needed.
+
+## Pyright suppressions
+
+<!--
+Per `CONTRIBUTING.md`, every `# pyright: report*=false` or inline
+`# pyright: ignore[...]` directive needs a documented reason and a
+tracking issue. If this PR adds, removes, or modifies any suppression,
+list each one and link the issue.
+-->
+
+- [ ] This PR does not introduce or modify any pyright suppression.
+- [ ] Suppressions added/changed are listed below with a link to the
+  tracking issue and a one-line rationale.
+
+## Linked issues
+
+<!--
+- `Closes #N` for a bug or feature this PR resolves outright.
+- `Refs #N` for an issue this PR makes progress on but doesn't close.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1] - 2026-05-01
+## [0.2.0] - 2026-05-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   panproto sort name is `"Union <a> <b> ..."` in canonical order; the
   encoder JSON-encodes the value, and the decoder dispatches on the
   resulting Python type. ([#2], [#3])
-
-### Notes
-
-- Recursive type aliases (e.g. a self-referential `JsonValue`) remain
-  unsupported and continue to raise `TypeNotSupportedError`. The
-  representation question (a new opaque `Json` sort vs. a tagged sum)
-  is tracked in [#2] for a later release.
+- JSON-shaped recursive type aliases translate to a single opaque
+  panproto sort named after the alias. The motivating shape is the
+  canonical `JsonValue` alias (`str | int | float | bool | None |
+  list[X] | tuple[X, ...] | dict[str, X]` with `X` self-referential).
+  The encoded form is `json.dumps(value)`; the decoder parses and
+  recursively coerces lists to tuples to satisfy didactic's
+  tuple-based `FieldValue` type. Recursive aliases that are *not*
+  JSON-shaped (e.g. one admitting `bytes`) raise
+  `TypeNotSupportedError` with a clear message rather than failing
+  silently. ([#2])
 
 [#2]: https://github.com/panproto/didactic/issues/2
 [#3]: https://github.com/panproto/didactic/issues/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-01
+
+### Added
+
+- Bare PEP 695 type aliases now translate transparently. `type Kind =
+  Literal["a", "b", "c"]` is accepted as a Model field annotation; the
+  classifier unwraps the alias before dispatching. ([#2])
+- Union of primitive scalars is a translatable field type. `int | str`,
+  `float | str`, `int | float | str`, and the same unions inside
+  `dict[str, V]` and `T | None` are accepted. The synthesised
+  panproto sort name is `"Union <a> <b> ..."` in canonical order; the
+  encoder JSON-encodes the value, and the decoder dispatches on the
+  resulting Python type. ([#2], [#3])
+
+### Notes
+
+- Recursive type aliases (e.g. a self-referential `JsonValue`) remain
+  unsupported and continue to raise `TypeNotSupportedError`. The
+  representation question (a new opaque `Json` sort vs. a tagged sum)
+  is tracked in [#2] for a later release.
+
+[#2]: https://github.com/panproto/didactic/issues/2
+[#3]: https://github.com/panproto/didactic/issues/3
+
 ## [0.1.0] - 2026-05-01
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.1.0"
+version = "0.1.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.1.1"
+version = "0.2.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.1.1"
+version = "0.2.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.1.0"
+version = "0.1.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.1.1"
+version = "0.2.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.1.1"
+version = "0.2.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -37,6 +37,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
+from functools import reduce
 from types import EllipsisType, NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
@@ -312,30 +313,102 @@ def _scalar_translation(typ: type) -> TypeTranslation:
 def _strip_optional(typ: TypeForm) -> tuple[TypeForm, bool]:
     """Peel a single ``T | None`` layer; return ``(inner, was_optional)``.
 
-    Anything beyond a binary ``T | None`` is left to the caller, which
-    will raise a TypeNotSupportedError for general unions (didactic
-    expresses sums via ``dx.TaggedUnion``, not via raw unions).
+    The returned inner may itself be a union (``int | str``); the caller
+    is responsible for classifying it via ``_classify_primitive_union``.
     """
     origin = get_origin(typ)
     if origin in {Union, UnionType}:
-        args = [a for a in get_args(typ) if a is not NoneType]
-        non_none = list(get_args(typ))
-        had_none = NoneType in non_none
-        if had_none and len(args) == 1:
-            return args[0], True
-        if had_none and len(args) > 1:
-            msg = (
-                "didactic does not yet support unions of more than one non-None "
-                f"type; got {typ!r}. Use a dx.TaggedUnion subclass."
-            )
-            raise TypeNotSupportedError(msg)
-        if not had_none:
-            msg = (
-                "didactic does not yet support raw Python unions without None; "
-                f"got {typ!r}. Use a dx.TaggedUnion subclass."
-            )
-            raise TypeNotSupportedError(msg)
+        non_none = [a for a in get_args(typ) if a is not NoneType]
+        had_none = NoneType in get_args(typ)
+        if had_none and len(non_none) == 1:
+            return non_none[0], True
+        if had_none and len(non_none) > 1:
+            # rebuild the union without None via PEP 604 ``|``; the
+            # ``X | Y`` operator is the only PEP-604-compliant way to
+            # construct a ``UnionType`` from a runtime sequence. The
+            # local lambda avoids ``operator.or_``'s partially-typed
+            # typeshed stub.
+            def _union(a: TypeForm, b: TypeForm) -> TypeForm:
+                return cast("TypeForm", a | b)
+
+            return reduce(_union, non_none), True
     return typ, False
+
+
+# ---------------------------------------------------------------------------
+# Union of primitive scalars
+# ---------------------------------------------------------------------------
+
+
+def _classify_primitive_union(args: tuple[TypeForm, ...]) -> TypeTranslation:
+    """Classify a union whose every arm is a registered scalar.
+
+    The encoded form is a JSON literal (``42``, ``"hello"``, ``1.5``); the
+    decoder uses ``json.loads`` and dispatches on the resulting Python
+    type. The synthesised sort name lists each arm's panproto sort in a
+    canonical order so that equivalent unions produce the same sort.
+    """
+    arms: list[type] = []
+    for arm in args:
+        if not (isinstance(arm, type) and arm in _SCALARS):
+            msg = (
+                "didactic supports unions only when every arm is a registered "
+                f"scalar; got arm {arm!r} in union {args!r}. Use a "
+                "dx.TaggedUnion subclass for richer sums."
+            )
+            raise TypeNotSupportedError(msg)
+        arms.append(arm)
+
+    # canonical order: by sort name, deduplicated. Preserves runtime
+    # behaviour while making ``int | str`` and ``str | int`` agree.
+    arms_by_sort = {_SCALARS[a][0]: a for a in arms}
+    sorted_sorts = sorted(arms_by_sort)
+    sort = "Union " + " ".join(_paren(s) for s in sorted_sorts)
+
+    def enc(v: FieldValue) -> Encoded:
+        # bool is an int subclass; check it first so ``True`` doesn't
+        # decode as ``1`` on the int arm.
+        for arm in (bool, *(a for a in arms if a is not bool)):
+            if arm in arms_by_sort.values() and isinstance(v, arm):
+                return json.dumps(v if not isinstance(v, bytes) else v.hex())
+        msg = f"value {v!r} did not match any arm of union {arms!r}"
+        raise TypeError(msg)
+
+    def dec(s: Encoded) -> FieldValue:
+        loaded = json.loads(s)
+        return _dispatch_union_arm(loaded, arms_by_sort)
+
+    def from_json(value: JsonValue) -> FieldValue:
+        return _dispatch_union_arm(value, arms_by_sort)
+
+    return TypeTranslation(
+        sort=sort,
+        encode=enc,
+        decode=dec,
+        inner_kind="scalar",
+        from_json=from_json,
+    )
+
+
+def _dispatch_union_arm(value: JsonValue, arms_by_sort: dict[str, type]) -> FieldValue:
+    """Pick the union arm whose Python type matches ``value`` and decode."""
+    arms = list(arms_by_sort.values())
+    # bool first (subclass of int)
+    if bool in arms and isinstance(value, bool):
+        return value
+    for arm in arms:
+        if arm is bool:
+            continue
+        if isinstance(value, arm):
+            # the matched scalar arm is a subset of FieldValue; the
+            # union narrowing on ``value`` keeps it as JsonValue so we
+            # cast at the boundary.
+            return cast("FieldValue", value)
+    msg = (
+        f"value {value!r} (type {type(value).__name__}) did not match any "
+        f"arm of union {arms!r}"
+    )
+    raise TypeError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -346,17 +419,28 @@ def _strip_optional(typ: TypeForm) -> tuple[TypeForm, bool]:
 def _expand_type_alias(typ: TypeForm) -> TypeForm:
     """Substitute concrete arguments through a PEP 695 type alias.
 
-    Given ``Foo[X, Y]`` where ``Foo`` is a ``TypeAliasType`` such as
-    ``type Foo[T, U] = Annotated[T, ..., U]``, return the alias's
-    ``__value__`` with each ``TypeVar`` replaced by the matching
-    argument. The didactic ``Embed`` and ``Ref`` aliases are the only
-    in-tree producers of this shape; non-alias inputs pass through
-    unchanged.
+    Two shapes are recognised:
+
+    1. ``Foo[X, Y]`` where ``Foo`` is a ``TypeAliasType`` such as
+       ``type Foo[T, U] = Annotated[T, ..., U]``. Returns the alias's
+       ``__value__`` with each ``TypeVar`` replaced by the matching
+       argument. The didactic ``Embed`` and ``Ref`` aliases are the
+       only in-tree producers of this shape.
+    2. A bare ``TypeAliasType`` such as ``type Kind = Literal["a","b"]``.
+       Returns the alias's ``__value__`` directly.
 
     Substitution walks one level of ``Annotated[...]`` and replaces type
     variables that appear either as the base type or anywhere in the
     metadata tuple. Other type-alias shapes are out of scope.
     """
+    # bare alias: ``type Kind = Literal[...]``. ``TypeAliasType`` falls
+    # outside the static ``TypeForm`` union (which only covers nominal
+    # ``type`` and ``UnionType``), so the isinstance check needs an
+    # ``object`` view of ``typ``.
+    if isinstance(cast("object", typ), TypeAliasType):
+        alias = cast("TypeAliasType", typ)
+        return cast("TypeForm", alias.__value__)
+    # parameterised alias: ``Foo[X, Y]``
     origin = get_origin(typ)
     if not isinstance(origin, TypeAliasType):
         return typ
@@ -668,6 +752,11 @@ def classify(typ: TypeForm) -> TypeTranslation:  # noqa: PLR0911
     # parameterised generics
     origin = get_origin(inner_type)
     args = get_args(inner_type)
+
+    # union of primitive scalars (e.g. ``int | str``); raw unions of
+    # non-primitives still raise via _classify_primitive_union below.
+    if origin in {Union, UnionType}:
+        return _classify_primitive_union(args)
 
     if origin is tuple:
         return _classify_tuple(args)

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -412,6 +412,130 @@ def _dispatch_union_arm(value: JsonValue, arms_by_sort: dict[str, type]) -> Fiel
 
 
 # ---------------------------------------------------------------------------
+# Recursive JSON-shaped type aliases
+# ---------------------------------------------------------------------------
+
+# A "JSON-shaped" recursive type alias is one whose ``__value__`` is built
+# entirely from primitive scalars (str/int/float/bool/None), the
+# JSON-compatible containers ``list[X]``/``tuple[X, ...]``/``dict[str, X]``,
+# unions of these, and self-references (which appear as bare strings inside
+# the alias body, e.g. ``list["JsonValue"]``). The motivating shape is::
+#
+#     type JsonValue = (
+#         str | int | float | bool | None
+#         | list["JsonValue"] | tuple["JsonValue", ...]
+#         | dict[str, "JsonValue"]
+#     )
+#
+# Such aliases are treated as opaque values of a single panproto sort
+# named after the alias (``"JsonValue"`` in the example above). The
+# encoded form is a JSON literal; the decoder is ``json.loads`` plus a
+# recursive ``list -> tuple`` coercion so the result satisfies didactic's
+# tuple-based ``FieldValue`` type. Recursive aliases that are NOT
+# JSON-shaped (e.g. one that admits ``bytes`` or a non-Model class) are
+# rejected with a clear error rather than silently accepted.
+
+_JSON_PRIMITIVE_TYPES: frozenset[type] = frozenset({str, int, float, bool, NoneType})
+
+
+def _arm_is_json_shape(arm: object, alias_name: str, alias_id: int, depth: int) -> bool:
+    """Return True iff ``arm`` is a JSON-shaped type expression.
+
+    Uses ``alias_name`` to recognise self-reference forward strings, and
+    ``alias_id`` to recognise self-reference via ``TypeAliasType``
+    identity. ``depth`` bounds recursion to guard against pathological
+    nesting (e.g. mutual recursion not yet supported).
+    """
+    if depth > 64:
+        return False
+    if isinstance(arm, type) and arm in _JSON_PRIMITIVE_TYPES:
+        return True
+    if isinstance(arm, str) and arm == alias_name:
+        return True
+    if isinstance(arm, TypeAliasType) and id(arm) == alias_id:
+        return True
+    origin = get_origin(arm)
+    args = get_args(arm)
+    if origin is list:
+        return len(args) == 1 and _arm_is_json_shape(
+            args[0], alias_name, alias_id, depth + 1
+        )
+    if origin is tuple:
+        return (
+            len(args) == 2
+            and args[1] is Ellipsis
+            and _arm_is_json_shape(args[0], alias_name, alias_id, depth + 1)
+        )
+    if origin is dict:
+        return (
+            len(args) == 2
+            and args[0] is str
+            and _arm_is_json_shape(args[1], alias_name, alias_id, depth + 1)
+        )
+    if origin in {Union, UnionType}:
+        return all(_arm_is_json_shape(a, alias_name, alias_id, depth + 1) for a in args)
+    return False
+
+
+def _has_self_reference(typ: object, alias_name: str, alias_id: int) -> bool:
+    """Return True iff ``typ``'s structure references the alias by name or identity."""
+    if isinstance(typ, str) and typ == alias_name:
+        return True
+    if isinstance(typ, TypeAliasType) and id(typ) == alias_id:
+        return True
+    args = get_args(typ)
+    return any(
+        a is not Ellipsis and _has_self_reference(a, alias_name, alias_id) for a in args
+    )
+
+
+def _coerce_lists_to_tuples(v: JsonValue) -> FieldValue:
+    """Walk a JSON-decoded value, converting every ``list`` to ``tuple``.
+
+    didactic's ``FieldValue`` is a tuple-based recursive type (no mutable
+    ``list``); JSON-decode produces lists. This coercion bridges the two
+    so that values flowing out of the JSON-shaped translation satisfy
+    ``FieldValue`` immutability.
+    """
+    if isinstance(v, list):
+        return tuple(_coerce_lists_to_tuples(item) for item in v)
+    if isinstance(v, dict):
+        return {k: _coerce_lists_to_tuples(val) for k, val in v.items()}
+    # primitives pass through; bool/int/float/str/None are FieldValue leaves.
+    return cast("FieldValue", v)
+
+
+def _json_alias_translation(alias_name: str) -> TypeTranslation:
+    """Build a TypeTranslation for a JSON-shaped recursive alias.
+
+    The encoded form is ``json.dumps(value)`` (which natively converts
+    tuples to JSON arrays). Decoding parses the JSON and coerces any
+    decoded lists to tuples. ``from_json`` performs the same coercion
+    on values that have already been JSON-decoded by an outer layer.
+    """
+
+    def enc(v: FieldValue) -> Encoded:
+        # ``json.dumps`` raises ``TypeError`` for non-JSON-shaped values
+        # (bytes, Decimal, Model instances, etc.). That's the right
+        # behaviour: the alias declared the value space.
+        return json.dumps(v)
+
+    def dec(s: Encoded) -> FieldValue:
+        return _coerce_lists_to_tuples(json.loads(s))
+
+    def from_json(v: JsonValue) -> FieldValue:
+        return _coerce_lists_to_tuples(v)
+
+    return TypeTranslation(
+        sort=alias_name,
+        encode=enc,
+        decode=dec,
+        inner_kind="scalar",
+        from_json=from_json,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Annotated handling
 # ---------------------------------------------------------------------------
 
@@ -419,15 +543,20 @@ def _dispatch_union_arm(value: JsonValue, arms_by_sort: dict[str, type]) -> Fiel
 def _expand_type_alias(typ: TypeForm) -> TypeForm:
     """Substitute concrete arguments through a PEP 695 type alias.
 
-    Two shapes are recognised:
+    Three shapes are recognised:
 
     1. ``Foo[X, Y]`` where ``Foo`` is a ``TypeAliasType`` such as
        ``type Foo[T, U] = Annotated[T, ..., U]``. Returns the alias's
        ``__value__`` with each ``TypeVar`` replaced by the matching
        argument. The didactic ``Embed`` and ``Ref`` aliases are the
        only in-tree producers of this shape.
-    2. A bare ``TypeAliasType`` such as ``type Kind = Literal["a","b"]``.
-       Returns the alias's ``__value__`` directly.
+    2. A bare non-recursive ``TypeAliasType`` such as
+       ``type Kind = Literal["a","b"]``. Returns the alias's
+       ``__value__`` directly.
+    3. A recursive JSON-shaped ``TypeAliasType`` such as the canonical
+       ``JsonValue``. Returns the alias *unchanged* so that ``classify``
+       can build a ``_json_alias_translation`` for it. (Unwrapping a
+       recursive alias would loop on the self-reference.)
 
     Substitution walks one level of ``Annotated[...]`` and replaces type
     variables that appear either as the base type or anywhere in the
@@ -439,6 +568,20 @@ def _expand_type_alias(typ: TypeForm) -> TypeForm:
     # ``object`` view of ``typ``.
     if isinstance(cast("object", typ), TypeAliasType):
         alias = cast("TypeAliasType", typ)
+        # recursive alias: leave unwrapped so classify can build the
+        # JSON-fixpoint translation. Reject recursive aliases that are
+        # not JSON-shaped early, with a clear message.
+        if _has_self_reference(alias.__value__, alias.__name__, id(alias)):
+            if not _arm_is_json_shape(alias.__value__, alias.__name__, id(alias), 0):
+                msg = (
+                    f"recursive type alias {alias.__name__!r} contains an arm "
+                    "that is not JSON-shaped (allowed: primitive scalars, "
+                    "list[X], tuple[X, ...], dict[str, X], unions of these, "
+                    "and self-references). Restrict the alias to the "
+                    "JSON-compatible subset, or use a dx.TaggedUnion."
+                )
+                raise TypeNotSupportedError(msg)
+            return cast("TypeForm", alias)
         return cast("TypeForm", alias.__value__)
     # parameterised alias: ``Foo[X, Y]``
     origin = get_origin(typ)
@@ -674,7 +817,7 @@ def _classify_literal(args: tuple[FieldValue, ...]) -> TypeTranslation:
 # ---------------------------------------------------------------------------
 
 
-def classify(typ: TypeForm) -> TypeTranslation:  # noqa: PLR0911
+def classify(typ: TypeForm) -> TypeTranslation:
     """Classify a Python type hint and return a TypeTranslation.
 
     Parameters
@@ -698,8 +841,16 @@ def classify(typ: TypeForm) -> TypeTranslation:  # noqa: PLR0911
     unwrap_annotated : split Annotated metadata before calling classify.
     """
     # Expand PEP 695 type aliases (``Embed[T]``, ``Ref[T]``) so the
-    # downstream Annotated logic sees the underlying form.
+    # downstream Annotated logic sees the underlying form. Recursive
+    # JSON-shaped aliases come back unwrapped; we detect them here and
+    # build the JSON-fixpoint translation directly.
     typ = _expand_type_alias(typ)
+    if isinstance(cast("object", typ), TypeAliasType):
+        alias = cast("TypeAliasType", typ)
+        # _expand_type_alias only returns a ``TypeAliasType`` when it has
+        # already validated that the alias is a JSON-shaped recursive
+        # alias (otherwise it unwraps or raises).
+        return _json_alias_translation(alias.__name__)
     # Annotated[T, ...]; strip metadata, recurse on the base
     if get_origin(typ) is Annotated:
         base, metadata = unwrap_annotated(typ)

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -208,3 +208,67 @@ def test_nested_dict_of_optional() -> None:
     src: dict[str, FieldValue] = {"a": 1, "b": None}
     decoded = t.decode(t.encode(src))
     assert decoded == src
+
+
+# -- PEP 695 type aliases (gh #2.1) ----------------------------------------
+
+type _AliasedKind = Literal["a", "b", "c"]
+type _AliasedInt = int
+
+
+def test_pep695_alias_to_literal_translates() -> None:
+    t = classify(_AliasedKind)
+    assert t.sort.startswith("Enum")
+    assert t.decode(t.encode("a")) == "a"
+
+
+def test_pep695_alias_to_scalar_translates() -> None:
+    t = classify(_AliasedInt)
+    assert t.sort == "Int"
+    assert t.decode(t.encode(7)) == 7
+
+
+def test_pep695_alias_inside_dict_translates() -> None:
+    t = classify(dict[str, _AliasedKind])
+    assert t.sort.startswith("Map String (Enum")
+    src: dict[str, FieldValue] = {"x": "a", "y": "b"}
+    assert t.decode(t.encode(src)) == src
+
+
+# -- union of primitives (gh #3, #2.3) -------------------------------------
+
+
+def test_union_int_str_translates() -> None:
+    t = classify(int | str)
+    assert "Int" in t.sort and "String" in t.sort
+    assert t.decode(t.encode(42)) == 42
+    assert t.decode(t.encode("hello")) == "hello"
+
+
+def test_union_float_str_round_trip() -> None:
+    t = classify(float | str)
+    assert t.decode(t.encode(1.5)) == 1.5
+    assert t.decode(t.encode("verse_2")) == "verse_2"
+
+
+def test_union_with_none_then_two_primitives() -> None:
+    t = classify(int | str | None)
+    assert t.is_optional
+    assert t.decode(t.encode(None)) is None
+    assert t.decode(t.encode(7)) == 7
+    assert t.decode(t.encode("x")) == "x"
+
+
+def test_dict_value_union_of_primitives() -> None:
+    t = classify(dict[str, int | float | str])
+    src: dict[str, FieldValue] = {"a": 1, "b": 2.5, "c": "tag"}
+    decoded = t.decode(t.encode(src))
+    assert decoded == src
+
+
+def test_union_of_non_primitives_still_rejected() -> None:
+    class _M:
+        pass
+
+    with pytest.raises(TypeNotSupportedError):
+        classify(int | _M)

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -272,3 +272,114 @@ def test_union_of_non_primitives_still_rejected() -> None:
 
     with pytest.raises(TypeNotSupportedError):
         classify(int | _M)
+
+
+# -- recursive JSON-shaped type aliases (gh #2.2) --------------------------
+
+type _JsonValue = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["_JsonValue"]
+    | tuple["_JsonValue", ...]
+    | dict[str, "_JsonValue"]
+)
+
+
+def test_recursive_json_alias_classifies_as_named_sort() -> None:
+    t = classify(_JsonValue)
+    assert t.sort == "_JsonValue"
+
+
+def test_recursive_json_alias_round_trips_primitives() -> None:
+    t = classify(_JsonValue)
+    for value in ("hello", 42, 1.5, True, False, None):
+        assert t.decode(t.encode(value)) == value
+
+
+def test_recursive_json_alias_round_trips_nested_dict() -> None:
+    t = classify(_JsonValue)
+    src: object = {"a": 1, "b": {"c": [1, 2, 3], "d": None}, "e": True}
+    decoded = t.decode(t.encode(src))
+    # lists become tuples on decode (FieldValue is tuple-based, not list)
+    assert decoded == {"a": 1, "b": {"c": (1, 2, 3), "d": None}, "e": True}
+
+
+def test_recursive_json_alias_tuple_round_trips_as_tuple() -> None:
+    t = classify(_JsonValue)
+    src = (1, "x", (2, 3))
+    decoded = t.decode(t.encode(src))
+    assert decoded == (1, "x", (2, 3))
+
+
+def test_recursive_json_alias_inside_dict_value() -> None:
+    t = classify(dict[str, _JsonValue])
+    src: dict[str, object] = {"k": [1, {"nested": "v"}]}
+    decoded = t.decode(t.encode(src))
+    assert decoded == {"k": (1, {"nested": "v"})}
+
+
+def test_recursive_json_alias_optional() -> None:
+    t = classify(_JsonValue | None)
+    assert t.is_optional
+    assert t.decode(t.encode(None)) is None
+    assert t.decode(t.encode({"a": 1})) == {"a": 1}
+
+
+def test_recursive_json_alias_from_json_coerces_lists_to_tuples() -> None:
+    t = classify(_JsonValue)
+    assert t.from_json([1, [2, 3]]) == (1, (2, 3))
+
+
+type _BadRecursive = str | int | bytes | list["_BadRecursive"]
+type _AliasedBool = bool
+
+
+def test_recursive_alias_with_non_json_arm_rejected() -> None:
+    # ``bytes`` is not in the JSON-shape allow-list; the recursive alias
+    # is rejected rather than silently accepted.
+    with pytest.raises(TypeNotSupportedError):
+        classify(_BadRecursive)
+
+
+def test_non_recursive_alias_unaffected() -> None:
+    """Plain non-recursive aliases keep the existing unwrap-and-recurse path."""
+    t = classify(_AliasedBool)
+    assert t.sort == "Bool"
+
+
+# -- recursive alias as a Model field --------------------------------------
+
+import didactic.api as dx  # noqa: E402
+
+type _Params = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["_Params"]
+    | tuple["_Params", ...]
+    | dict[str, "_Params"]
+)
+
+
+class _Variation(dx.Model):
+    kind: str
+    params: dict[str, _Params]
+
+
+def test_recursive_json_alias_works_as_model_field() -> None:
+    """The neume use case: ``dict[str, JsonValue]`` on a real Model."""
+    v = _Variation(
+        kind="transposition",
+        params={"semitones": 5, "tags": ["a", "b"], "meta": {"v": 1.0}},
+    )
+    raw = v.model_dump_json()
+    v2 = _Variation.model_validate_json(raw)
+    # lists round-trip as tuples (FieldValue is tuple-based).
+    assert v2.params["semitones"] == 5
+    assert v2.params["tags"] == ("a", "b")
+    assert v2.params["meta"] == {"v": 1.0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ extend-ignore-names = ["A", "B", "T", "P"]
 # the json-schema emitter has a long if-elif chain matching annotated-types
 # primitives; expanding it doesn't help readability
 "**/_json_schema.py" = ["PLR0911", "PLR0912"]
+# ``_types.py`` houses the multi-shape origin dispatch (list/tuple/dict/union/
+# self-ref) for JSON-shape detection; flattening into helpers obscures the
+# table of cases.
+"**/types/_types.py" = ["PLR0911"]
 # model_dump's option matrix is genuinely n-flag and requires per-flag
 # checks; splitting into helpers would just hide the same logic
 "**/models/_model.py" = ["PLR0912"]

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Fills three type-translation gaps reported during neume integration. ``classify`` now accepts bare PEP 695 type aliases (``type Kind = Literal[...]``), unions of primitive scalars (``int | str``, ``float | str``), and JSON-shaped recursive aliases (the canonical ``JsonValue`` shape).

Closes #2. Closes #3.

## Motivation

neume's ``Variation`` model needed three idiomatic Python typing constructs:

- ``type VariationKind = Literal[\"transposition\", ...]`` — a PEP 695 alias to a Literal, the language-blessed replacement for ``typing.TypeAlias``.
- ``position: float | str`` — a finite union of primitives, where neume's anchor is either a numeric beat position or a named-section string.
- ``params: dict[str, JsonValue]`` — a recursive JSON-shaped value, ubiquitous for kernel parameters and lens hints.

All three previously raised ``TypeNotSupportedError``, forcing neume to encode-as-JSON-string-and-decode-via-property workarounds that lose type-checker friendliness. didactic's own ``FieldValue`` is itself a JSON-shaped recursive alias, so the underlying machinery existed; it just wasn't reachable from the field surface.

## Changes

- ``packages/didactic/src/didactic/types/_types.py`` —
  - ``_expand_type_alias`` now handles bare ``TypeAliasType`` instances (not just parameterised ``Foo[X, Y]``). Recursive aliases come back unchanged so ``classify`` can build a fixpoint translation; non-recursive aliases unwrap as before.
  - ``_strip_optional`` no longer raises on multi-non-None unions; it returns the non-None remainder rebuilt as a real ``UnionType``.
  - New ``_classify_primitive_union`` translates unions whose every arm is a registered scalar. Sort name is ``\"Union <a> <b>\"`` in canonical order; encoder JSON-encodes; decoder dispatches on the parsed Python type. Non-primitive arms still raise.
  - New ``_arm_is_json_shape`` / ``_has_self_reference`` / ``_coerce_lists_to_tuples`` / ``_json_alias_translation`` machinery for JSON-shaped recursive aliases. Sort name is the alias's ``__name__``; encoder is ``json.dumps``; decoder is ``json.loads`` plus a recursive ``list -> tuple`` coercion to satisfy didactic's tuple-based ``FieldValue``.
  - Recursive aliases that are not JSON-shaped (e.g. one admitting ``bytes``, ``Decimal``, a Model class) are rejected at expansion time with an explicit message pointing at the JSON-compatible subset.
- ``pyproject.toml`` — adds a ``PLR0911`` per-file ignore on ``_types.py`` for the multi-shape origin dispatch (consistent with the existing carve-outs for ``_axiom_enforcement.py`` and ``_json_schema.py``).
- ``CHANGELOG.md`` — new ``[0.2.0]`` section documenting all three additions and noting that non-JSON-shaped recursive aliases remain rejected.
- Version bumped 0.1.0 -> 0.2.0 across all four package ``pyproject.toml`` files and ``__version__`` constants. Minor (not patch) because the new feature surface is bigger than a 0.1.x patch.
- ``.github/pull_request_template.md`` — new file; conventions for future PRs.

## Tests

18 new tests in ``packages/didactic/tests/test_types.py``:

- PEP 695 aliases: alias-to-Literal, alias-to-scalar, alias-as-dict-value.
- Primitive unions: ``int | str``, ``float | str``, ``int | str | None``, ``dict[str, int | float | str]``, and a negative test for ``int | _NonScalarClass``.
- Recursive JSON aliases: the named-sort property, primitive round-trip, nested-dict round-trip with ``list -> tuple`` coercion, tuple-stays-tuple, ``dict[str, JsonValue]``, ``JsonValue | None``, ``from_json`` coercion, the non-JSON-shaped rejection (``bytes`` arm), the non-recursive alias falling through unchanged.
- Integration: a ``Model`` with ``params: dict[str, _Params]`` round-trips via ``model_dump_json`` (the exact neume use case).

## Local CI

- [x] ``uv run ruff format --check``
- [x] ``uv run ruff check``
- [x] ``uv run pyright``
- [x] ``uv run pytest -ra`` — 442 pass
- [x] ``uv run mkdocs build --strict``

## Compatibility

- **Backwards-compatible addition.** Existing fields keep working byte-for-byte; the changes only widen what ``classify`` accepts. No public symbol removed or repurposed.

## Changelog

- [x] Added a ``CHANGELOG.md`` entry under ``[0.2.0] - 2026-05-01``.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression. The ``_types.py`` per-file ignore was a pre-existing carve-out; this PR only adds a ``PLR0911`` ruff per-file ignore (different tool, different rule, documented in ``pyproject.toml``).

## Linked issues

- Closes #2
- Closes #3
- Refs #1 (pyright-suppression unwind tracked separately; deferred per maintainer direction)