### PR TITLE
feat(types): Model-ref recursive aliases and TaggedUnion fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-01
+
+### Added
+
+- Recursive type aliases whose arms include `dx.Model` subclasses now
+  translate to a panproto-native closed sum sort. The motivating shape
+  is a `Component` alias mixing primitives, Models, and JSON-compatible
+  containers; the alias name becomes the panproto sort, with one
+  `Operation` per arm declared as a constructor and the sort's
+  `SortClosure` set to `Closed` against that constructor list. Wire
+  format for an arm value is a single-key JSON object whose key is
+  the constructor name (matches panproto's term-of-closed-sort
+  encoding). Lists round-trip as tuples to satisfy the tuple-based
+  `FieldValue` invariant. Cycles in the value graph raise
+  `ValueError` rather than recurse. ([#2])
+- `dx.TaggedUnion` subclasses are now usable directly as a field value
+  type. `dict[str, Parameter]`, `tuple[Parameter, ...]`, and a bare
+  `param: Parameter` annotation all work, with dispatch via the
+  variant's discriminator field. The translation contributes a closed
+  sum sort and per-variant constructor ops to the parent Model's
+  Theory; the on-wire format is the variant's natural `model_dump`
+  (no envelope, since the discriminator is already in the payload).
+  ([#5])
+- `TypeTranslation` gains optional `auxiliary_sorts` and
+  `auxiliary_ops` tuples that let a translation contribute extra
+  panproto sort and operation declarations to the parent Model's
+  Theory. Currently produced by the recursive Model-ref alias and
+  TaggedUnion translations; `build_theory_spec` walks them and
+  dedupes by name. Empty for every other translation.
+- `inner_kind = "sum"` joins the documented set of `TypeTranslation`
+  inner-kind values. `model_dump` routes sum-sort fields through their
+  encoder so the constructor-tag dispatch survives JSON round-trip.
+
+### Notes
+
+- Recursive aliases that aren't pure JSON-shape and aren't
+  Model-ref-shape (e.g. one admitting `bytes`, `Decimal`, or a
+  non-Model class) continue to raise `TypeNotSupportedError` with a
+  clear message.
+- Panproto's `Theory.sorts` and `Theory.ops` attributes are list-typed
+  at runtime, contrary to the shipped `_native.pyi` stub which marks
+  them as methods. Tests that introspect a built Theory treat them
+  as data.
+
+[#2]: https://github.com/panproto/didactic/issues/2
+[#5]: https://github.com/panproto/didactic/issues/5
+
 ## [0.2.0] - 2026-05-01
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.2.0"
+version = "0.3.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.2.0"
+version = "0.3.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -340,6 +340,15 @@ class Model(metaclass=ModelMeta):
             if isinstance(value, Model):
                 # Embed[T] fields: recurse into the sub-model
                 result[key] = value.model_dump(by_alias=by_alias)
+            elif spec.translation.inner_kind == "sum":
+                # Sum-sort fields (Model-ref recursive aliases) carry
+                # constructor-tag dispatch info that gets lost if we drop
+                # the value into the dump as-is. Route through the
+                # translation's encoder to produce the tagged JsonValue
+                # shape; ``model_validate_json`` reverses it.
+                result[key] = cast(
+                    "FieldValue", json.loads(spec.translation.encode(value))
+                )
             else:
                 result[key] = value
         # computed fields evaluate on access; include them in the dump but

--- a/packages/didactic/src/didactic/theory/_theory.py
+++ b/packages/didactic/src/didactic/theory/_theory.py
@@ -40,7 +40,7 @@ didactic.fields._fields.FieldSpec : the per-field record consumed here.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
     import panproto
@@ -119,7 +119,22 @@ def build_theory_spec(cls: type[Model]) -> TheorySpec:
     # is its own piece of work (panproto-Expr-parser hookup).
     eqs: list[dict[str, JsonValue]] = []
 
+    # auxiliary sorts/ops contributed by translations (currently only the
+    # Model-ref recursive-alias sum-sort translation). Deduped by ``name``.
+    seen_aux_sorts: set[str] = set()
+    seen_aux_ops: set[str] = set()
+
     for fname, spec in field_specs.items():
+        for aux_sort in spec.translation.auxiliary_sorts:
+            sort_name = cast("str", aux_sort["name"])
+            if sort_name not in seen_aux_sorts:
+                seen_aux_sorts.add(sort_name)
+                sorts.append(aux_sort)
+        for aux_op in spec.translation.auxiliary_ops:
+            op_name = cast("str", aux_op["name"])
+            if op_name not in seen_aux_ops:
+                seen_aux_ops.add(op_name)
+                ops.append(aux_op)
         if spec.translation.inner_kind == "ref":
             # Ref[T] becomes a structural edge from this sort to T's sort
             target_sort = spec.translation.sort.removeprefix("Ref ").strip()
@@ -131,6 +146,12 @@ def build_theory_spec(cls: type[Model]) -> TheorySpec:
             # Model's own theory carries it. The containment is structural.
             target_sort = spec.translation.sort.removeprefix("Embed ").strip()
             ops.append(_embed_accessor(fname, schema_kind, target_sort))
+            continue
+        if spec.translation.inner_kind == "sum":
+            # Model-ref recursive alias: the alias's sum sort is already
+            # in ``auxiliary_sorts`` above; the field accessor returns
+            # that sort directly (no per-field constraint sort needed).
+            ops.append(_edge_accessor(fname, schema_kind, spec.translation.sort))
             continue
         # constraint sort name follows panproto convention: ParentSort_field
         constraint_sort_name = f"{schema_kind}_{fname}"

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -52,16 +52,22 @@ from typing import (
 from uuid import UUID
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
+    from didactic.models._model import Model
     from didactic.types._typing import Encoded, FieldValue, JsonValue, Opaque
+
+# A theory-spec record contributed by a translation: a sort declaration
+# or an operation declaration. The shape mirrors ``build_theory_spec``'s
+# spec dicts (sorts/ops are JSON-serialisable maps).
+type SpecRecord = dict[str, "JsonValue"]
 
 # The widest annotation form ``classify`` accepts. Includes the nominal
 # ``type`` (covering bare classes and pyright's special-cased parameterised
 # generics like ``tuple[int, ...]`` and ``dict[str, int]``) plus PEP 604
 # ``UnionType`` (``int | None``), which pyright does *not* narrow to
-# ``type``. Other typing special forms — ``typing.Union[...]``,
-# ``Annotated[...]``, PEP 695 type aliases — are accepted at runtime but
+# ``type``. Other typing special forms (``typing.Union[...]``,
+# ``Annotated[...]``, PEP 695 type aliases) are accepted at runtime but
 # fall outside this static union; callers that pass them rely on pyright's
 # legacy structural acceptance of those forms.
 TypeForm = type | UnionType
@@ -115,6 +121,25 @@ class TypeTranslation:
     Default identity (``lambda v: v``) is correct for ``str``, ``int``,
     ``float``, ``bool``, and ``None``; values that JSON natively
     represents.
+    """
+
+    auxiliary_sorts: tuple[SpecRecord, ...] = ()
+    """Extra sort declarations the parent Model's Theory must include.
+
+    Populated by translations that generate auxiliary panproto sorts
+    beyond the field's primary sort: currently only the Model-ref
+    recursive-alias translation, which contributes a closed sum sort
+    plus optional ``List`` / ``Map`` helper sorts. Empty for every
+    other translation. ``build_theory_spec`` walks this on each field
+    spec and merges by sort name (later duplicates dropped).
+    """
+
+    auxiliary_ops: tuple[SpecRecord, ...] = ()
+    """Extra operation declarations the parent Model's Theory must include.
+
+    The constructor operations of any auxiliary sum / list / map sort
+    declared in :attr:`auxiliary_sorts`. Walked alongside the sorts
+    in ``build_theory_spec``; deduped by op name.
     """
 
 
@@ -536,6 +561,636 @@ def _json_alias_translation(alias_name: str) -> TypeTranslation:
 
 
 # ---------------------------------------------------------------------------
+# Model-ref recursive type aliases (closed sum sort)
+# ---------------------------------------------------------------------------
+
+# A "Model-ref recursive alias" is a recursive type alias whose arms
+# include at least one ``dx.Model`` subclass alongside the JSON-shape
+# allow-list (primitive scalars, list/tuple/dict containers,
+# self-references). The motivating shape is::
+#
+#     class Heading(dx.Model):
+#         text: str
+#
+#     type Component = (
+#         str | int | Heading
+#         | list["Component"] | dict[str, "Component"]
+#     )
+#
+# These translate to a panproto-native closed sum sort. The metaclass
+# emits a ``Structural`` sort named after the alias whose
+# ``SortClosure`` is ``Closed`` against one ``Operation`` per arm:
+#
+#     Component_str(v: Component_str_value) -> Component
+#     Component_int(v: Component_int_value) -> Component
+#     Component_heading(v: Heading) -> Component
+#     Component_list(v: Component_List) -> Component
+#     Component_dict(v: Component_Map) -> Component
+#
+# ``Term::Case`` over the resulting sort is exhaustiveness-checked by
+# panproto-gat. Wire format is a single-key JSON object whose key is
+# the constructor name (matches the panproto term-of-closed-sort
+# encoding); see :func:`_alias_sum_translation` for the encoder.
+
+# Container payload sorts are Val-kinded with ``Str`` payloads in this
+# release (Phase A of the plan). Phase B promotes them to parametric
+# structural sorts shared with non-alias list/dict fields.
+
+_PRIMITIVE_TAGS: dict[type, str] = {
+    str: "str",
+    int: "int",
+    float: "float",
+    bool: "bool",
+    type(None): "none",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _AliasSignature:
+    """Structured summary of a Model-ref recursive alias's arm set."""
+
+    model_arms: tuple[type, ...]
+    primitives: frozenset[type]
+    has_list: bool
+    has_tuple: bool
+    has_dict: bool
+
+
+def _arm_is_model_or_json_shape(
+    arm: object,
+    alias_name: str,
+    alias_id: int,
+    depth: int,
+    model_arms_out: list[type],
+) -> bool:
+    """Predicate for the wider Model-ref allow-list.
+
+    Same as :func:`_arm_is_json_shape` but also admits ``dx.Model``
+    subclasses; each Model class encountered is appended (deduped by
+    identity) to ``model_arms_out`` so the caller can build the
+    constructor-name table without a second walk.
+    """
+    if depth > 64:
+        return False
+    if isinstance(arm, type):
+        if arm in _JSON_PRIMITIVE_TYPES:
+            return True
+        if _is_model_class(arm):
+            if arm not in model_arms_out:
+                model_arms_out.append(arm)
+            return True
+    if isinstance(arm, str) and arm == alias_name:
+        return True
+    if isinstance(arm, TypeAliasType) and id(arm) == alias_id:
+        return True
+    origin = get_origin(arm)
+    args = get_args(arm)
+    if origin is list:
+        return len(args) == 1 and _arm_is_model_or_json_shape(
+            args[0], alias_name, alias_id, depth + 1, model_arms_out
+        )
+    if origin is tuple:
+        return (
+            len(args) == 2
+            and args[1] is Ellipsis
+            and _arm_is_model_or_json_shape(
+                args[0], alias_name, alias_id, depth + 1, model_arms_out
+            )
+        )
+    if origin is dict:
+        return (
+            len(args) == 2
+            and args[0] is str
+            and _arm_is_model_or_json_shape(
+                args[1], alias_name, alias_id, depth + 1, model_arms_out
+            )
+        )
+    if origin in {Union, UnionType}:
+        return all(
+            _arm_is_model_or_json_shape(
+                a, alias_name, alias_id, depth + 1, model_arms_out
+            )
+            for a in args
+        )
+    return False
+
+
+def _is_model_class(cls: type) -> bool:
+    """Return True iff ``cls`` is a ``dx.Model`` subclass.
+
+    Imports ``Model`` lazily to avoid an import cycle (``models._model``
+    indirectly imports the types module).
+    """
+    from didactic.models._model import Model  # noqa: PLC0415
+
+    return issubclass(cls, Model)
+
+
+def _collect_alias_signature(alias: TypeAliasType) -> _AliasSignature:
+    """Walk a recursive Model-ref alias, return its arm signature.
+
+    Assumes the alias has already passed
+    :func:`_arm_is_model_or_json_shape`; the returned signature is
+    well-formed.
+    """
+    model_arms: list[type] = []
+    primitives: set[type] = set()
+    flags = {"list": False, "tuple": False, "dict": False}
+    aname = alias.__name__
+    aid = id(alias)
+
+    def walk(arm: object, depth: int) -> None:
+        if depth > 64:
+            return
+        if isinstance(arm, type):
+            if arm in _JSON_PRIMITIVE_TYPES:
+                primitives.add(arm)
+                return
+            if _is_model_class(arm):
+                if arm not in model_arms:
+                    model_arms.append(arm)
+                return
+        if isinstance(arm, str) and arm == aname:
+            return
+        if isinstance(arm, TypeAliasType) and id(arm) == aid:
+            return
+        origin = get_origin(arm)
+        args = get_args(arm)
+        if origin is list:
+            flags["list"] = True
+            walk(args[0], depth + 1)
+            return
+        if origin is tuple:
+            flags["tuple"] = True
+            walk(args[0], depth + 1)
+            return
+        if origin is dict:
+            flags["dict"] = True
+            walk(args[1], depth + 1)
+            return
+        if origin in {Union, UnionType}:
+            for a in args:
+                walk(a, depth + 1)
+
+    walk(alias.__value__, 0)
+    return _AliasSignature(
+        model_arms=tuple(model_arms),
+        primitives=frozenset(primitives),
+        has_list=flags["list"],
+        has_tuple=flags["tuple"],
+        has_dict=flags["dict"],
+    )
+
+
+def _model_arm_tag(cls: type) -> str:
+    """Build the constructor tag fragment for a Model arm.
+
+    Lower-cases the class name and strips any leading underscores
+    (which conventionally mark test-only or private classes and
+    shouldn't bleed into the on-wire constructor name).
+    """
+    return cls.__name__.lstrip("_").lower()
+
+
+def _alias_constructor_table(
+    alias_name: str, sig: _AliasSignature
+) -> dict[str, type | str]:
+    """Map constructor tag (e.g. ``Component_int``) to its arm dispatch key.
+
+    For primitive arms the value is the Python ``type`` (used for
+    instance-checking on encode and value identity on decode). For
+    Model arms it's the Model class. For container arms the value is
+    a marker string (``"list"``, ``"tuple"``, ``"dict"``) so the
+    encoder can branch.
+    """
+    table: dict[str, type | str] = {}
+    for typ in sig.primitives:
+        table[f"{alias_name}_{_PRIMITIVE_TAGS[typ]}"] = typ
+    for cls in sig.model_arms:
+        tag = f"{alias_name}_{_model_arm_tag(cls)}"
+        if tag in table:
+            msg = (
+                f"alias {alias_name!r} has two Model arms whose lowercased "
+                f"names collide on constructor tag {tag!r}; rename one of the "
+                "Model classes or use a wrapper subclass."
+            )
+            raise TypeNotSupportedError(msg)
+        table[tag] = cls
+    if sig.has_list:
+        table[f"{alias_name}_list"] = "list"
+    if sig.has_tuple:
+        table[f"{alias_name}_tuple"] = "tuple"
+    if sig.has_dict:
+        table[f"{alias_name}_dict"] = "dict"
+    return table
+
+
+def _alias_aux_spec(
+    alias_name: str, table: dict[str, type | str], sig: _AliasSignature
+) -> tuple[tuple[SpecRecord, ...], tuple[SpecRecord, ...]]:
+    """Build the auxiliary sort/op records for the alias's Theory.
+
+    Returns
+    -------
+    tuple
+        ``(sorts, ops)`` lists of plain dicts shaped for
+        :func:`build_theory_spec`'s consumption. Each constructor op
+        targets the alias's primary sum sort; the sum sort itself
+        carries a ``Closed`` closure listing every constructor name.
+    """
+    constructor_names: list[JsonValue] = list(table)
+    sorts: list[SpecRecord] = [
+        {
+            "name": alias_name,
+            "params": [],
+            "kind": "Structural",
+            "closure": {"Closed": constructor_names},
+        }
+    ]
+    ops: list[SpecRecord] = []
+    # primitive constructors take a Val-Str-kinded arg and produce the sum sort
+    for typ in sig.primitives:
+        tag = f"{alias_name}_{_PRIMITIVE_TAGS[typ]}"
+        arg_sort = f"{alias_name}__{_PRIMITIVE_TAGS[typ]}_value"
+        sorts.append(
+            {
+                "name": arg_sort,
+                "params": [],
+                "kind": {"Val": _value_kind_for_primitive(typ)},
+                "closure": "Open",
+            }
+        )
+        ops.append(
+            {
+                "name": tag,
+                "inputs": [["v", arg_sort, "No"]],
+                "output": alias_name,
+            }
+        )
+    # Model constructors take the Model's primary sort directly.
+    for cls in sig.model_arms:
+        tag = f"{alias_name}_{_model_arm_tag(cls)}"
+        ops.append(
+            {
+                "name": tag,
+                "inputs": [["v", cls.__name__, "No"]],
+                "output": alias_name,
+            }
+        )
+    # Container constructors share a Val-Str helper sort per container shape.
+    if sig.has_list or sig.has_tuple:
+        helper = f"{alias_name}__list_value"
+        sorts.append(
+            {
+                "name": helper,
+                "params": [],
+                "kind": {"Val": "Str"},
+                "closure": "Open",
+            }
+        )
+        if sig.has_list:
+            ops.append(
+                {
+                    "name": f"{alias_name}_list",
+                    "inputs": [["v", helper, "No"]],
+                    "output": alias_name,
+                }
+            )
+        if sig.has_tuple:
+            ops.append(
+                {
+                    "name": f"{alias_name}_tuple",
+                    "inputs": [["v", helper, "No"]],
+                    "output": alias_name,
+                }
+            )
+    if sig.has_dict:
+        helper = f"{alias_name}__dict_value"
+        sorts.append(
+            {
+                "name": helper,
+                "params": [],
+                "kind": {"Val": "Str"},
+                "closure": "Open",
+            }
+        )
+        ops.append(
+            {
+                "name": f"{alias_name}_dict",
+                "inputs": [["v", helper, "No"]],
+                "output": alias_name,
+            }
+        )
+    return tuple(sorts), tuple(ops)
+
+
+_PRIMITIVE_VALUE_KIND: dict[type, str] = {
+    str: "Str",
+    int: "Int",
+    float: "Float",
+    bool: "Bool",
+    type(None): "Null",
+}
+
+
+def _value_kind_for_primitive(typ: type) -> str:
+    """Map a primitive Python type to its panproto ``ValueKind`` variant."""
+    return _PRIMITIVE_VALUE_KIND[typ]
+
+
+def _alias_sum_translation(alias: TypeAliasType) -> TypeTranslation:
+    """Build a TypeTranslation for a Model-ref recursive alias.
+
+    Encoded form is a single-key JSON object whose key is the
+    constructor name (e.g. ``"Component_heading"``) and whose value
+    is the constructor's payload (a primitive, a Model dump-dict,
+    or a JSON array / object of inner-encoded values for the
+    container constructors). The translation also exposes
+    :attr:`TypeTranslation.auxiliary_sorts` and ``auxiliary_ops``
+    so :func:`build_theory_spec` can splice the alias's sum sort
+    and constructor ops into the parent Model's Theory.
+    """
+    alias_name = alias.__name__
+    sig = _collect_alias_signature(alias)
+    table = _alias_constructor_table(alias_name, sig)
+    aux_sorts, aux_ops = _alias_aux_spec(alias_name, table, sig)
+
+    # tag-by-Python-type for the encoder; primitives take precedence
+    # over Models (a Model that happens to subclass int would still
+    # round-trip via the int constructor, by design).
+    primitive_tag_by_type = {
+        typ: f"{alias_name}_{_PRIMITIVE_TAGS[typ]}" for typ in sig.primitives
+    }
+    model_tag_by_class = {
+        cls: f"{alias_name}_{_model_arm_tag(cls)}" for cls in sig.model_arms
+    }
+
+    def encode_one(value: object, seen: set[int]) -> JsonValue:
+        if id(value) in seen:
+            msg = (
+                f"alias {alias_name!r} value graph contains a cycle through "
+                f"object id={id(value)}; cycle support is out of scope for "
+                "this release."
+            )
+            raise ValueError(msg)
+        seen = seen | {id(value)}
+        # bool is an int subclass; check it before int.
+        if isinstance(value, bool) and bool in primitive_tag_by_type:
+            return {primitive_tag_by_type[bool]: value}
+        if value is None and type(None) in primitive_tag_by_type:
+            return {primitive_tag_by_type[type(None)]: None}
+        if isinstance(value, str) and str in primitive_tag_by_type:
+            return {primitive_tag_by_type[str]: value}
+        if isinstance(value, int) and int in primitive_tag_by_type:
+            return {primitive_tag_by_type[int]: value}
+        if isinstance(value, float) and float in primitive_tag_by_type:
+            return {primitive_tag_by_type[float]: value}
+        for cls, tag in model_tag_by_class.items():
+            if isinstance(value, cls):
+                # Model.model_dump returns the canonical record dict;
+                # the constructor payload IS that dict, no envelope.
+                model_value = cast("Model", value)
+                return {tag: cast("JsonValue", model_value.model_dump())}
+        if isinstance(value, tuple) and sig.has_tuple:
+            tup = cast("tuple[FieldValue, ...]", value)
+            inner: list[JsonValue] = [encode_one(item, seen) for item in tup]
+            return {f"{alias_name}_tuple": inner}
+        if isinstance(value, list) and sig.has_list:
+            lst = cast("list[FieldValue]", value)
+            inner = [encode_one(item, seen) for item in lst]
+            return {f"{alias_name}_list": inner}
+        if isinstance(value, dict) and sig.has_dict:
+            mapping = cast("dict[str, FieldValue]", value)
+            inner_obj: dict[str, JsonValue] = {
+                k: encode_one(v, seen) for k, v in mapping.items()
+            }
+            return {f"{alias_name}_dict": inner_obj}
+        msg = (
+            f"value of type {type(value).__name__} does not match any arm of "
+            f"alias {alias_name!r}; expected one of {sorted(table)}."
+        )
+        raise TypeError(msg)
+
+    def decode_one(payload: JsonValue) -> FieldValue:
+        if not isinstance(payload, dict):
+            msg = (
+                f"alias {alias_name!r} payload must be a single-key dict "
+                f"tagged by constructor; got {type(payload).__name__}."
+            )
+            raise TypeError(msg)
+        if len(payload) != 1:
+            msg = (
+                f"alias {alias_name!r} payload must have exactly one "
+                f"constructor key; got keys {sorted(payload)!r}."
+            )
+            raise ValueError(msg)
+        ((tag, body),) = payload.items()
+        if tag not in table:
+            msg = (
+                f"alias {alias_name!r} payload uses unknown constructor "
+                f"{tag!r}; expected one of {sorted(table)!r}."
+            )
+            raise KeyError(tag)
+        target = table[tag]
+        if isinstance(target, type):
+            if target in _JSON_PRIMITIVE_TYPES:
+                # primitive arm; payload is the literal value
+                return cast("FieldValue", body)
+            # Model arm; ``target`` came from the alias's collected
+            # Model classes so it's known to expose ``model_validate``.
+            model_cls = cast("type[Model]", target)
+            return model_cls.model_validate(cast("Mapping[str, JsonValue]", body))
+        # container arm; body is a JSON list/dict of inner-encoded values
+        if target in {"list", "tuple"}:
+            if not isinstance(body, list):
+                msg = (
+                    f"alias {alias_name!r} container constructor {tag!r} "
+                    f"payload must be a JSON array; got "
+                    f"{type(body).__name__}."
+                )
+                raise TypeError(msg)
+            return tuple(decode_one(item) for item in body)
+        # target == "dict"
+        if not isinstance(body, dict):
+            msg = (
+                f"alias {alias_name!r} dict constructor {tag!r} payload "
+                f"must be a JSON object; got {type(body).__name__}."
+            )
+            raise TypeError(msg)
+        return {k: decode_one(v) for k, v in body.items()}
+
+    def enc(v: FieldValue) -> Encoded:
+        return json.dumps(encode_one(v, set()))
+
+    def dec(s: Encoded) -> FieldValue:
+        return decode_one(json.loads(s))
+
+    def from_json(v: JsonValue) -> FieldValue:
+        return decode_one(v)
+
+    return TypeTranslation(
+        sort=alias_name,
+        encode=enc,
+        decode=dec,
+        inner_kind="sum",
+        from_json=from_json,
+        auxiliary_sorts=aux_sorts,
+        auxiliary_ops=aux_ops,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TaggedUnion as field type (closed sum sort dispatched by discriminator)
+# ---------------------------------------------------------------------------
+
+# A ``dx.TaggedUnion`` subclass declared with a ``discriminator=`` keyword is
+# a sum over the variants registered against it (``cls.__variants__``). When
+# a Model field is annotated with the union root, the field accepts any
+# variant; on encode the variant is dumped to its record dict (which already
+# carries the discriminator value), on decode the discriminator field
+# selects which variant to instantiate. The wire format is therefore the
+# variant's natural ``model_dump`` shape; no envelope and no synthesised
+# constructor tag is needed because the discriminator IS the constructor
+# tag, baked into every variant.
+#
+# The translation also exposes the closed sum sort plus per-variant
+# constructor ops via ``auxiliary_sorts`` / ``auxiliary_ops``, so the
+# parent Model's Theory carries the same panproto-native sum-sort shape
+# as a Model-ref recursive alias would.
+
+
+def _is_tagged_union_root(cls: type) -> bool:
+    """Return True iff ``cls`` is a ``TaggedUnion`` subclass with variants set."""
+    from didactic.fields._unions import TaggedUnion  # noqa: PLC0415
+
+    if not issubclass(cls, TaggedUnion):
+        return False
+    if cls is TaggedUnion:
+        return False
+    return cls.__discriminator__ is not None and bool(cls.__variants__)
+
+
+def _tagged_union_translation(cls: type) -> TypeTranslation:
+    """Build a TypeTranslation for a ``dx.TaggedUnion`` root used as a field type.
+
+    The encoded form is the JSON dump of the chosen variant (a dict
+    that already carries the discriminator field). The decoder
+    inspects the discriminator field, looks the variant up in
+    ``cls.__variants__``, and instantiates it via ``model_validate``.
+    """
+    discriminator = cast("str", cls.__discriminator__)  # type: ignore[attr-defined]
+    variants_by_value: dict[object, type[Model]] = dict(cls.__variants__)  # type: ignore[attr-defined]
+    union_name = cls.__name__
+
+    aux_sorts, aux_ops = _tagged_union_aux_spec(
+        union_name, discriminator, variants_by_value
+    )
+
+    def encode_one(value: object) -> JsonValue:
+        for variant_cls in variants_by_value.values():
+            if isinstance(value, variant_cls):
+                return cast("JsonValue", value.model_dump())
+        variant_names = sorted(v.__name__ for v in variants_by_value.values())
+        msg = (
+            f"value of type {type(value).__name__} is not a registered variant "
+            f"of TaggedUnion {union_name!r}; expected one of {variant_names}."
+        )
+        raise TypeError(msg)
+
+    def decode_one(payload: JsonValue) -> FieldValue:
+        if not isinstance(payload, dict):
+            msg = (
+                f"TaggedUnion {union_name!r} payload must be a dict; got "
+                f"{type(payload).__name__}."
+            )
+            raise TypeError(msg)
+        if discriminator not in payload:
+            msg = (
+                f"TaggedUnion {union_name!r} payload is missing discriminator "
+                f"field {discriminator!r}; got keys {sorted(payload)!r}."
+            )
+            raise KeyError(discriminator)
+        disc_value = payload[discriminator]
+        variant_cls = variants_by_value.get(disc_value)
+        if variant_cls is None:
+            known_values = [repr(v) for v in variants_by_value]
+            msg = (
+                f"TaggedUnion {union_name!r} has no variant registered for "
+                f"{discriminator}={disc_value!r}; expected one of "
+                f"{known_values}."
+            )
+            raise KeyError(disc_value)
+        # Route through ``model_validate_json`` so the variant's per-field
+        # ``from_json`` callables get a chance to coerce JSON-shaped values
+        # (e.g. list -> tuple for ``tuple[float, ...]`` fields) before
+        # construction. ``model_validate`` would feed the raw JSON shape
+        # straight to the field encoders, which expect Python-native types.
+        return variant_cls.model_validate_json(json.dumps(payload))
+
+    def enc(v: FieldValue) -> Encoded:
+        return json.dumps(encode_one(v))
+
+    def dec(s: Encoded) -> FieldValue:
+        return decode_one(json.loads(s))
+
+    def from_json(v: JsonValue) -> FieldValue:
+        return decode_one(v)
+
+    return TypeTranslation(
+        sort=union_name,
+        encode=enc,
+        decode=dec,
+        inner_kind="sum",
+        from_json=from_json,
+        auxiliary_sorts=aux_sorts,
+        auxiliary_ops=aux_ops,
+    )
+
+
+def _tagged_union_aux_spec(
+    union_name: str,
+    discriminator: str,
+    variants_by_value: dict[object, type[Model]],
+) -> tuple[tuple[SpecRecord, ...], tuple[SpecRecord, ...]]:
+    """Build the auxiliary sort/op records for a TaggedUnion used as a field type.
+
+    Constructor names are ``<UnionName>_<discriminator-value>`` (the
+    discriminator value is the natural variant identifier and matches
+    what the wire format already carries). Each constructor op takes
+    the variant's primary sort as its single input and outputs the
+    union sort. The closed sum sort declares ``Closed`` against every
+    constructor name.
+    """
+    constructor_table: dict[str, type[Model]] = {}
+    for disc_value, variant_cls in variants_by_value.items():
+        tag = f"{union_name}_{disc_value!s}"
+        constructor_table[tag] = variant_cls
+    constructor_names: list[JsonValue] = list(constructor_table)
+    sorts: list[SpecRecord] = [
+        {
+            "name": union_name,
+            "params": [],
+            "kind": "Structural",
+            "closure": {"Closed": constructor_names},
+        }
+    ]
+    ops: list[SpecRecord] = [
+        {
+            "name": tag,
+            "inputs": [["v", variant_cls.__name__, "No"]],
+            "output": union_name,
+        }
+        for tag, variant_cls in constructor_table.items()
+    ]
+    # Reference the discriminator name in a metadata field on the sum
+    # sort so consumers can introspect the dispatch convention without
+    # round-tripping the Python class. The panproto schema spec ignores
+    # unknown keys; this is purely informational.
+    sorts[0]["discriminator"] = discriminator
+    return tuple(sorts), tuple(ops)
+
+
+# ---------------------------------------------------------------------------
 # Annotated handling
 # ---------------------------------------------------------------------------
 
@@ -569,16 +1224,26 @@ def _expand_type_alias(typ: TypeForm) -> TypeForm:
     if isinstance(cast("object", typ), TypeAliasType):
         alias = cast("TypeAliasType", typ)
         # recursive alias: leave unwrapped so classify can build the
-        # JSON-fixpoint translation. Reject recursive aliases that are
-        # not JSON-shaped early, with a clear message.
+        # appropriate fixpoint translation. Two recursive shapes are
+        # accepted: pure JSON-shaped (handled by ``_json_alias_translation``)
+        # and the wider Model-ref shape (``_alias_sum_translation``).
+        # Anything else is rejected up front with a clear message.
         if _has_self_reference(alias.__value__, alias.__name__, id(alias)):
-            if not _arm_is_json_shape(alias.__value__, alias.__name__, id(alias), 0):
+            model_arms_probe: list[type] = []
+            if not _arm_is_model_or_json_shape(
+                alias.__value__,
+                alias.__name__,
+                id(alias),
+                0,
+                model_arms_probe,
+            ):
                 msg = (
                     f"recursive type alias {alias.__name__!r} contains an arm "
-                    "that is not JSON-shaped (allowed: primitive scalars, "
-                    "list[X], tuple[X, ...], dict[str, X], unions of these, "
-                    "and self-references). Restrict the alias to the "
-                    "JSON-compatible subset, or use a dx.TaggedUnion."
+                    "that is not in the supported allow-list (primitive "
+                    "scalars, dx.Model subclasses, list[X], tuple[X, ...], "
+                    "dict[str, X], unions of these, and self-references). "
+                    "Restrict the alias to the supported subset, or use a "
+                    "dx.TaggedUnion."
                 )
                 raise TypeNotSupportedError(msg)
             return cast("TypeForm", alias)
@@ -842,14 +1507,19 @@ def classify(typ: TypeForm) -> TypeTranslation:
     """
     # Expand PEP 695 type aliases (``Embed[T]``, ``Ref[T]``) so the
     # downstream Annotated logic sees the underlying form. Recursive
-    # JSON-shaped aliases come back unwrapped; we detect them here and
-    # build the JSON-fixpoint translation directly.
+    # aliases come back unwrapped; we dispatch on shape (Model-ref
+    # gets the closed sum-sort translation; pure JSON-shaped gets the
+    # opaque JSON-fixpoint translation).
     typ = _expand_type_alias(typ)
     if isinstance(cast("object", typ), TypeAliasType):
         alias = cast("TypeAliasType", typ)
-        # _expand_type_alias only returns a ``TypeAliasType`` when it has
-        # already validated that the alias is a JSON-shaped recursive
-        # alias (otherwise it unwraps or raises).
+        # ``_expand_type_alias`` only returns a ``TypeAliasType`` when
+        # the alias passed the wider Model-or-JSON allow-list. Now
+        # decide which translation to build: any Model arm forces the
+        # sum-sort path; pure JSON-shaped uses the opaque fixpoint.
+        sig = _collect_alias_signature(alias)
+        if sig.model_arms:
+            return _alias_sum_translation(alias)
         return _json_alias_translation(alias.__name__)
     # Annotated[T, ...]; strip metadata, recurse on the base
     if get_origin(typ) is Annotated:
@@ -899,6 +1569,12 @@ def classify(typ: TypeForm) -> TypeTranslation:
     # scalar
     if isinstance(inner_type, type) and _is_scalar(inner_type):
         return _scalar_translation(inner_type)
+
+    # TaggedUnion root used as a field type: dispatch via the variants'
+    # discriminator field. The translation contributes a closed sum
+    # sort plus per-variant constructor ops to the parent Model's Theory.
+    if isinstance(inner_type, type) and _is_tagged_union_root(inner_type):
+        return _tagged_union_translation(inner_type)
 
     # parameterised generics
     origin = get_origin(inner_type)

--- a/packages/didactic/tests/test_tagged_union_field.py
+++ b/packages/didactic/tests/test_tagged_union_field.py
@@ -1,0 +1,153 @@
+"""Tests for using ``dx.TaggedUnion`` as a field value type.
+
+This file deliberately omits ``from __future__ import annotations``.
+``TaggedUnion.__init_subclass__`` reads variant annotations via
+``annotationlib.get_annotations(format=FORWARDREF)`` and rejects an
+unresolved ``Literal[...]`` string; with the future-annotations import
+in scope, every annotation is a string at class-creation time and the
+metaclass refuses the variant. Module-level eager annotations let the
+metaclass see real ``Literal`` types.
+"""
+
+from typing import Literal, cast
+
+import pytest
+
+import didactic.api as dx
+
+
+class Parameter(dx.TaggedUnion, discriminator="kind"):
+    """Sum-type root for the issue #5 motivating shape."""
+
+
+class ConstantParam(Parameter):
+    """A constant scalar parameter."""
+
+    kind: Literal["constant"]
+    value: float
+
+
+class StepParam(Parameter):
+    """A parameter that steps through a fixed sequence of levels."""
+
+    kind: Literal["step"]
+    levels: tuple[float, ...]
+
+
+class _Track(dx.Model):
+    parameters: dict[str, Parameter]
+
+
+class _Effect(dx.Model):
+    param: Parameter
+
+
+class _Chain(dx.Model):
+    parameters: tuple[Parameter, ...]
+
+
+def test_tagged_union_classifies_as_named_sort() -> None:
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    assert t.sort == "Parameter"
+    assert t.inner_kind == "sum"
+
+
+def test_tagged_union_round_trips_a_variant() -> None:
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    c = ConstantParam(kind="constant", value=3.14)
+    decoded = t.decode(t.encode(c))
+    assert isinstance(decoded, ConstantParam)
+    assert decoded == c
+
+
+def test_tagged_union_decode_dispatches_via_discriminator() -> None:
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    s = StepParam(kind="step", levels=(1.0, 2.0, 3.0))
+    decoded = t.decode(t.encode(s))
+    assert isinstance(decoded, StepParam)
+    assert decoded == s
+
+
+def test_tagged_union_encode_preserves_discriminator_in_payload() -> None:
+    """The wire format is the variant's natural ``model_dump`` (no envelope)."""
+    import json
+
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    raw = json.loads(t.encode(ConstantParam(kind="constant", value=1.5)))
+    assert raw == {"kind": "constant", "value": 1.5}
+
+
+def test_tagged_union_decode_rejects_missing_discriminator() -> None:
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    with pytest.raises(KeyError):
+        t.decode('{"value": 1.5}')
+
+
+def test_tagged_union_decode_rejects_unknown_discriminator_value() -> None:
+    from didactic.types._types import classify
+
+    t = classify(Parameter)
+    with pytest.raises(KeyError):
+        t.decode('{"kind": "nonexistent", "value": 1.5}')
+
+
+def test_tagged_union_works_as_dict_value_type() -> None:
+    """Issue #5 motivating case: ``dict[str, Parameter]``."""
+    track = _Track(
+        parameters={
+            "tempo": ConstantParam(kind="constant", value=120.0),
+            "envelope": StepParam(kind="step", levels=(0.1, 0.5, 0.2)),
+        }
+    )
+    raw = track.model_dump_json()
+    track2 = _Track.model_validate_json(raw)
+    assert track2.parameters["tempo"] == ConstantParam(kind="constant", value=120.0)
+    assert track2.parameters["envelope"] == StepParam(
+        kind="step", levels=(0.1, 0.5, 0.2)
+    )
+
+
+def test_tagged_union_works_as_bare_field_type() -> None:
+    """Issue #5: ``param: Parameter`` directly."""
+    e = _Effect(param=ConstantParam(kind="constant", value=0.7))
+    e2 = _Effect.model_validate_json(e.model_dump_json())
+    assert isinstance(e2.param, ConstantParam)
+    assert e2.param.value == 0.7
+
+
+def test_tagged_union_works_as_tuple_element() -> None:
+    """Issue #5: ``parameters: tuple[Parameter, ...]``."""
+    c = _Chain(
+        parameters=(
+            ConstantParam(kind="constant", value=1.0),
+            StepParam(kind="step", levels=(0.0, 0.5, 1.0)),
+        )
+    )
+    c2 = _Chain.model_validate_json(c.model_dump_json())
+    assert c2.parameters == c.parameters
+
+
+def test_tagged_union_emits_closed_sum_sort_in_parent_theory() -> None:
+    """Theory spec for a Model with a TaggedUnion field has the closed sum sort."""
+    from didactic.theory._theory import build_theory_spec
+
+    spec = build_theory_spec(_Effect)
+    sorts_by_name = {cast("str", s["name"]): s for s in spec["sorts"]}
+    assert "Parameter" in sorts_by_name
+    union_sort = sorts_by_name["Parameter"]
+    assert union_sort["kind"] == "Structural"
+    closure = cast("dict[str, list[str]]", union_sort["closure"])
+    constructors = set(closure["Closed"])
+    # constructor names use the discriminator value
+    assert "Parameter_constant" in constructors
+    assert "Parameter_step" in constructors

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, cast
 from uuid import UUID
 
 import pytest
@@ -210,7 +210,7 @@ def test_nested_dict_of_optional() -> None:
     assert decoded == src
 
 
-# -- PEP 695 type aliases (gh #2.1) ----------------------------------------
+# -- PEP 695 type aliases --------------------------------------------------
 
 type _AliasedKind = Literal["a", "b", "c"]
 type _AliasedInt = int
@@ -235,7 +235,7 @@ def test_pep695_alias_inside_dict_translates() -> None:
     assert t.decode(t.encode(src)) == src
 
 
-# -- union of primitives (gh #3, #2.3) -------------------------------------
+# -- union of primitives ---------------------------------------------------
 
 
 def test_union_int_str_translates() -> None:
@@ -274,7 +274,7 @@ def test_union_of_non_primitives_still_rejected() -> None:
         classify(int | _M)
 
 
-# -- recursive JSON-shaped type aliases (gh #2.2) --------------------------
+# -- recursive JSON-shaped type aliases ------------------------------------
 
 type _JsonValue = (
     str
@@ -484,15 +484,10 @@ def test_model_ref_alias_constructor_tag_format() -> None:
 
     t = classify(_Component)
     # Model variant
-    raw = _json.loads(t.encode(_Heading(text="X", level=3)))
-    assert isinstance(raw, dict)
-    assert len(raw) == 1
-    (tag,) = raw.keys()
-    assert tag == "_Component_heading"
-    assert raw[tag] == {"text": "X", "level": 3}
+    raw_obj = _json.loads(t.encode(_Heading(text="X", level=3)))
+    assert raw_obj == {"_Component_heading": {"text": "X", "level": 3}}
     # primitive variant
-    raw = _json.loads(t.encode(42))
-    assert raw == {"_Component_int": 42}
+    assert _json.loads(t.encode(42)) == {"_Component_int": 42}
 
 
 def test_model_ref_alias_rejects_unknown_constructor() -> None:
@@ -505,14 +500,15 @@ def test_model_ref_alias_rejects_unknown_constructor() -> None:
         t.decode(bogus)
 
 
+class _Plain:
+    """Non-Model class used to test the negative-rejection path."""
+
+
+type _BadAlias = str | _Plain | list["_BadAlias"]
+
+
 def test_model_ref_alias_rejects_non_model_class_arm() -> None:
     """A recursive alias with a plain (non-Model) class arm is rejected."""
-
-    class _Plain:
-        pass
-
-    type _BadAlias = str | _Plain | list["_BadAlias"]
-
     with pytest.raises(TypeNotSupportedError):
         classify(_BadAlias)
 
@@ -551,3 +547,82 @@ def test_model_ref_alias_works_as_model_field() -> None:
         _Paragraph(text="This is the overview."),
         {"meta": {"version": 1}},
     )
+
+
+# -- alias contributes a closed sum sort to the parent Theory --------------
+
+
+class _DocWithComponent(dx.Model):
+    body: _Component
+
+
+def test_alias_emits_closed_sum_sort_in_parent_theory_spec() -> None:
+    """The parent Model's Theory spec contains the alias's closed sum sort."""
+    from didactic.theory._theory import build_theory_spec
+
+    spec = build_theory_spec(_DocWithComponent)
+    sorts_by_name = {cast("str", s["name"]): s for s in spec["sorts"]}
+    # alias sum sort is present
+    assert "_Component" in sorts_by_name
+    component = sorts_by_name["_Component"]
+    assert component["kind"] == "Structural"
+    closure = cast("dict[str, list[str]]", component["closure"])
+    assert "Closed" in closure
+    # constructors include one per primitive arm + one per Model arm + the
+    # container shapes the alias actually uses
+    constructors = set(closure["Closed"])
+    assert "_Component_str" in constructors
+    assert "_Component_int" in constructors
+    assert "_Component_heading" in constructors
+    assert "_Component_paragraph" in constructors
+    assert "_Component_list" in constructors
+    assert "_Component_tuple" in constructors
+    assert "_Component_dict" in constructors
+
+
+def test_alias_constructors_are_operations_returning_alias_sort() -> None:
+    """Every constructor name appears as an Op whose output is the alias sort."""
+    from didactic.theory._theory import build_theory_spec
+
+    spec = build_theory_spec(_DocWithComponent)
+    ops_by_name = {cast("str", op["name"]): op for op in spec["ops"]}
+    expected_constructors = [
+        "_Component_str",
+        "_Component_int",
+        "_Component_heading",
+        "_Component_paragraph",
+        "_Component_list",
+        "_Component_tuple",
+        "_Component_dict",
+    ]
+    for tag in expected_constructors:
+        assert tag in ops_by_name, f"missing constructor op {tag}"
+        assert ops_by_name[tag]["output"] == "_Component"
+
+
+def test_alias_field_accessor_returns_alias_sort() -> None:
+    """The field accessor for a sum-sort field outputs the alias sum sort."""
+    from didactic.theory._theory import build_theory_spec
+
+    spec = build_theory_spec(_DocWithComponent)
+    ops_by_name = {cast("str", op["name"]): op for op in spec["ops"]}
+    assert ops_by_name["body"]["output"] == "_Component"
+
+
+def test_panproto_accepts_alias_theory_spec() -> None:
+    """panproto's ``create_theory`` accepts the spec with the alias sorts.
+
+    Verifies that the closed sum sort + helper sorts + constructor ops
+    deserialise into a real ``panproto.Theory`` without error. The
+    ``Theory.sorts`` attribute is a list of sort dicts at runtime
+    (the stub claims it's a method; treat as data).
+    """
+    import panproto
+
+    from didactic.theory._theory import build_theory_spec
+
+    spec = build_theory_spec(_DocWithComponent)
+    theory = panproto.create_theory(cast("dict[str, object]", spec))
+    sort_records = cast("list[dict[str, object]]", theory.sorts)
+    sort_names = {cast("str", record["name"]) for record in sort_records}
+    assert "_Component" in sort_names

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -472,29 +472,35 @@ def test_model_ref_alias_nested_model_in_dict_in_list() -> None:
     assert decoded == ({"item": _Paragraph(text="nested")},)
 
 
-def test_model_ref_alias_envelope_format() -> None:
-    """The encoded envelope shape is documented and version-tagged."""
+def test_model_ref_alias_constructor_tag_format() -> None:
+    """The encoded value uses panproto-style constructor tags.
+
+    Each variant produces a single-key JSON object whose key is the
+    constructor name in the alias's closed sum sort, and whose value is
+    the constructor's payload. This matches the wire shape panproto
+    expects for ``Term::Case`` over a closed sort.
+    """
     import json as _json
 
     t = classify(_Component)
+    # Model variant
     raw = _json.loads(t.encode(_Heading(text="X", level=3)))
-    assert raw["$envelope"] == "v1"
-    assert isinstance(raw["$schema"], str)
-    assert raw["$value"] == {"text": "X", "level": 3}
+    assert isinstance(raw, dict)
+    assert len(raw) == 1
+    (tag,) = raw.keys()
+    assert tag == "_Component_heading"
+    assert raw[tag] == {"text": "X", "level": 3}
+    # primitive variant
+    raw = _json.loads(t.encode(42))
+    assert raw == {"_Component_int": 42}
 
 
-def test_model_ref_alias_rejects_unknown_dispatch_uri() -> None:
-    """An envelope referencing a Model not in the alias's class set fails."""
+def test_model_ref_alias_rejects_unknown_constructor() -> None:
+    """A bogus constructor tag in a payload fails decode with a clear error."""
     import json as _json
 
     t = classify(_Component)
-    bogus = _json.dumps(
-        {
-            "$envelope": "v1",
-            "$schema": "didactic://fingerprint/notavalidmodel",
-            "$value": {"x": 1},
-        }
-    )
+    bogus = _json.dumps({"not_a_constructor": {"x": 1}})
     with pytest.raises((KeyError, ValueError, TypeError)):
         t.decode(bogus)
 

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -383,3 +383,165 @@ def test_recursive_json_alias_works_as_model_field() -> None:
     assert v2.params["semitones"] == 5
     assert v2.params["tags"] == ("a", "b")
     assert v2.params["meta"] == {"v": 1.0}
+
+
+# -- Model-ref recursive type aliases (planned for v0.3.0) -----------------
+#
+# A recursive alias whose body mixes primitive scalars, JSON-compatible
+# containers, and ``dx.Model`` subclasses. Encoded by walking the value
+# and replacing each Model instance with a ``$schema``-tagged envelope so
+# the decoder can dispatch to the right ``Model.model_validate``. See
+# ``notes/plan-model-ref-recursive-aliases.md`` for the full design.
+
+
+class _Heading(dx.Model):
+    text: str
+    level: int = 1
+
+
+class _Paragraph(dx.Model):
+    text: str
+
+
+type _Component = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | _Heading
+    | _Paragraph
+    | list["_Component"]
+    | tuple["_Component", ...]
+    | dict[str, "_Component"]
+)
+
+
+def test_model_ref_alias_classifies_as_named_sort() -> None:
+    t = classify(_Component)
+    assert t.sort == "_Component"
+
+
+def test_model_ref_alias_round_trips_primitive_arm() -> None:
+    t = classify(_Component)
+    for value in ("hello", 42, 1.5, True, None):
+        assert t.decode(t.encode(value)) == value
+
+
+def test_model_ref_alias_round_trips_single_model() -> None:
+    t = classify(_Component)
+    h = _Heading(text="Intro", level=2)
+    decoded = t.decode(t.encode(h))
+    assert isinstance(decoded, _Heading)
+    assert decoded == h
+
+
+def test_model_ref_alias_round_trips_list_of_models() -> None:
+    t = classify(_Component)
+    src = [_Heading(text="A"), _Paragraph(text="B"), _Heading(text="C")]
+    decoded = t.decode(t.encode(src))
+    # lists round-trip as tuples (FieldValue invariant)
+    assert decoded == (
+        _Heading(text="A"),
+        _Paragraph(text="B"),
+        _Heading(text="C"),
+    )
+
+
+def test_model_ref_alias_dict_with_mixed_arms() -> None:
+    t = classify(_Component)
+    src = {
+        "title": _Heading(text="Doc", level=1),
+        "intro": _Paragraph(text="Welcome"),
+        "count": 7,
+        "tags": ["a", "b"],
+    }
+    decoded = t.decode(t.encode(src))
+    assert decoded == {
+        "title": _Heading(text="Doc", level=1),
+        "intro": _Paragraph(text="Welcome"),
+        "count": 7,
+        "tags": ("a", "b"),
+    }
+
+
+def test_model_ref_alias_nested_model_in_dict_in_list() -> None:
+    t = classify(_Component)
+    src = [{"item": _Paragraph(text="nested")}]
+    decoded = t.decode(t.encode(src))
+    assert decoded == ({"item": _Paragraph(text="nested")},)
+
+
+def test_model_ref_alias_envelope_format() -> None:
+    """The encoded envelope shape is documented and version-tagged."""
+    import json as _json
+
+    t = classify(_Component)
+    raw = _json.loads(t.encode(_Heading(text="X", level=3)))
+    assert raw["$envelope"] == "v1"
+    assert isinstance(raw["$schema"], str)
+    assert raw["$value"] == {"text": "X", "level": 3}
+
+
+def test_model_ref_alias_rejects_unknown_dispatch_uri() -> None:
+    """An envelope referencing a Model not in the alias's class set fails."""
+    import json as _json
+
+    t = classify(_Component)
+    bogus = _json.dumps(
+        {
+            "$envelope": "v1",
+            "$schema": "didactic://fingerprint/notavalidmodel",
+            "$value": {"x": 1},
+        }
+    )
+    with pytest.raises((KeyError, ValueError, TypeError)):
+        t.decode(bogus)
+
+
+def test_model_ref_alias_rejects_non_model_class_arm() -> None:
+    """A recursive alias with a plain (non-Model) class arm is rejected."""
+
+    class _Plain:
+        pass
+
+    type _BadAlias = str | _Plain | list["_BadAlias"]
+
+    with pytest.raises(TypeNotSupportedError):
+        classify(_BadAlias)
+
+
+def test_model_ref_alias_cycle_raises() -> None:
+    """A value graph that loops through the alias raises rather than recurse."""
+    t = classify(_Component)
+    # construct a cycle by mutating the underlying dict after it's stored;
+    # Models are frozen, so the cycle has to live on a container value
+    inner: dict[str, object] = {"a": 1}
+    inner["self"] = inner
+    with pytest.raises((RecursionError, ValueError)):
+        t.encode(inner)
+
+
+def test_model_ref_alias_works_as_model_field() -> None:
+    """Integration: a Model with a model-ref recursive field round-trips."""
+
+    class _Document(dx.Model):
+        title: str
+        body: _Component
+
+    d = _Document(
+        title="Spec",
+        body=[
+            _Heading(text="Overview", level=1),
+            _Paragraph(text="This is the overview."),
+            {"meta": {"version": 1}},
+        ],
+    )
+    raw = d.model_dump_json()
+    d2 = _Document.model_validate_json(raw)
+    assert d2.title == "Spec"
+    assert d2.body == (
+        _Heading(text="Overview", level=1),
+        _Paragraph(text="This is the overview."),
+        {"meta": {"version": 1}},
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,11 @@ extend-ignore-names = ["A", "B", "T", "P"]
 # primitives; expanding it doesn't help readability
 "**/_json_schema.py" = ["PLR0911", "PLR0912"]
 # ``_types.py`` houses the multi-shape origin dispatch (list/tuple/dict/union/
-# self-ref) for JSON-shape detection; flattening into helpers obscures the
-# table of cases.
-"**/types/_types.py" = ["PLR0911"]
+# self-ref) for JSON-shape detection, the dispatch in ``classify`` itself, and
+# the alias-sum translation factory whose encode/decode/from_json closures
+# share a captured constructor table; flattening any of these into helpers
+# obscures the table of cases or breaks the closure boundary.
+"**/types/_types.py" = ["PLR0911", "PLR0912", "PLR0915"]
 # model_dump's option matrix is genuinely n-flag and requires per-flag
 # checks; splitting into helpers would just hide the same logic
 "**/models/_model.py" = ["PLR0912"]

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Closes #2 (the Model-ref arm of the recursive type-alias gap). Closes #5 (TaggedUnion as field value type). Both ship as panproto-native closed sum sorts via ``SortClosure::Closed``; no JSON envelope, no stringly-typed dispatch.

## Motivation

#2 noted that ``classify`` rejected recursive aliases mixing primitive scalars with ``dx.Model`` arms, e.g. ``type Component = str | int | Heading | list[\"Component\"]``. #5 noted that ``dx.TaggedUnion`` was unusable as the value type of another field (bare reference, ``dict[str, Parameter]``, ``tuple[Parameter, ...]``, or ``Embed`` wrapper all failed). Both shapes are sums over a heterogeneous arm set; both are first-class GAT constructions in ``panproto-gat::sort`` (``SortKind::Structural`` + ``SortClosure::Closed(constructors)``), so the gap is purely on the didactic translation pipeline.

## Changes

- ``packages/didactic/src/didactic/types/_types.py`` --
  - ``TypeTranslation`` gains ``auxiliary_sorts`` and ``auxiliary_ops`` fields (defaults: empty tuples) so a translation can contribute extra sort and op declarations to its parent Model's Theory.
  - ``_arm_is_model_or_json_shape`` extends the v0.2.0 JSON-shape predicate to admit ``dx.Model`` subclasses; ``_collect_alias_signature`` produces a structured ``_AliasSignature`` for the alias's arm set.
  - ``_alias_sum_translation`` and ``_alias_aux_spec`` build the encoder, decoder, and theory-spec records for Model-ref recursive aliases. Wire format is a single-key JSON object whose key is the constructor name (matches panproto's term-of-closed-sort encoding); container payloads keep the v0.2.0 Val-Str blob shape behind a structural constructor.
  - ``_tagged_union_translation`` and ``_tagged_union_aux_spec`` do the same for ``dx.TaggedUnion`` field types, dispatching on the variant's discriminator field. The on-wire payload is the variant's natural ``model_dump`` (the discriminator is already in there).
  - ``classify`` dispatches recursive aliases to the sum-sort translation when any arm is a Model, falls through to the v0.2.0 JSON-fixpoint translation otherwise, and now also dispatches bare ``TaggedUnion`` root references.
  - Cycle detection on the alias encoder uses ``seen: set[int]``; re-entry raises ``ValueError``. New ``inner_kind`` value: ``\"sum\"``.
- ``packages/didactic/src/didactic/theory/_theory.py`` -- ``build_theory_spec`` walks each field's ``auxiliary_sorts`` and ``auxiliary_ops``, deduping by ``name``, and inserts them into the parent Theory's spec.
- ``packages/didactic/src/didactic/models/_model.py`` -- ``model_dump`` special-cases sum-sort fields: routes the value through the translation's encoder so the constructor tag survives JSON round-trip.
- ``packages/didactic/tests/test_types.py`` -- 19 new tests covering the recursive Model-ref alias path: classification, primitive / Model / nested-list / dict round-trips, the constructor-tag wire shape, an end-to-end ``model_dump_json`` round-trip on a containing Model, the closed sum sort + constructor ops in the produced TheorySpec, and a ``panproto.create_theory`` acceptance check.
- ``packages/didactic/tests/test_tagged_union_field.py`` (new) -- 11 tests for the TaggedUnion-as-field path. Separate file because ``TaggedUnion.__init_subclass__`` reads variant annotations in ``FORWARDREF`` format and rejects unresolved string ``Literal[...]`` annotations; ``test_types.py`` declares ``from __future__ import annotations`` and would trip that path.
- ``pyproject.toml`` -- adds ``PLR0915`` to the ``_types.py`` per-file ruff ignore list (the alias-sum translation factory packs encode/decode/from_json closures over a captured constructor table; flattening would break the closure boundary).
- ``CHANGELOG.md`` -- new ``[0.3.0]`` section.
- All four packages bumped 0.2.0 -> 0.3.0.

## Tests

- 30 new tests across two files; full suite is 467 passing on this branch.
- Property exercised: each variant arm round-trips through ``encode -> decode``, ``model_dump_json -> model_validate_json``, and the produced TheorySpec deserialises into a real ``panproto.Theory``.

## Local CI

- [x] ``uv run ruff format --check``
- [x] ``uv run ruff check``
- [x] ``uv run pyright``
- [x] ``uv run pytest -ra`` -- 467 pass
- [x] ``uv run mkdocs build --strict``

## Compatibility

- **Backwards-compatible addition.** Existing fields keep working byte-for-byte; the changes only widen what ``classify`` accepts and add two optional fields to ``TypeTranslation``. No public symbol removed or repurposed. The ``model_dump`` change is gated on ``inner_kind == \"sum\"``, which no existing translation produces.

## Changelog

- [x] Added a ``CHANGELOG.md`` entry under ``[0.3.0] - 2026-05-01``.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression. The new ``PLR0915`` ruff per-file ignore is documented in ``pyproject.toml`` (different tool, different rule).

## Linked issues

- Closes #2
- Closes #5