### PR TITLE
fix(types): JSON round-trip across nested Embed and sum sorts (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-01
+
+### Fixed
+
+- Sum-sort encoders (closed Model-ref recursive aliases and TaggedUnion
+  field types) now route the chosen variant through ``model_dump_json``
+  instead of bare ``model_dump``, so any nested
+  ``tuple[Embed[T], ...]`` / ``dict[str, Embed[T]]`` / arbitrary
+  Model-containing structure inside the variant gets the JSON-safe
+  walk. Previously such payloads raised
+  ``Object of type X is not JSON serializable`` from ``json.dumps``.
+  ([#7])
+- ``Embed[Inner]`` round-trip via ``model_dump_json`` /
+  ``model_validate_json`` no longer asserts when ``Inner`` has a
+  ``tuple[T, ...]`` (or any ``from_json``-coerced) field. The embed
+  translation now routes inner JSON payloads through
+  ``model_validate_json`` so per-field ``from_json`` runs at every
+  level (e.g. JSON list to tuple coercion). ([#8])
+- ``model_dump`` evaluates ``inner_kind == "sum"`` before the
+  ``isinstance(value, Model)`` branch, so a Model variant of a
+  sum-sort field is dumped with its constructor tag instead of
+  collapsing to the variant's record dict. Previously a recursive
+  alias whose Model arm was the current value lost its dispatch
+  info on the dump side; the JSON round-trip then raised
+  ``unknown constructor`` on decode.
+- ``embed_schema_uri`` walks nested Model-containing fields via
+  ``model_dump_json`` so the returned dict is always serialisable;
+  previously failed with ``TypeError`` when the source instance had
+  a ``tuple[Embed[T], ...]`` field.
+
+### Changed
+
+- Recursive Model-ref alias encoders prefer the ``tuple`` constructor
+  over the ``list`` constructor when both arms are declared, even for
+  Python ``list`` input. This keeps the encoded storage form
+  canonical: round-tripping a Python list and re-encoding produces
+  the same constructor name and the same storage string, restoring
+  ``Model`` equality across the round-trip.
+
+[#7]: https://github.com/panproto/didactic/issues/7
+[#8]: https://github.com/panproto/didactic/issues/8
+
 ## [0.3.0] - 2026-05-01
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.3.0"
+version = "0.3.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.3.0"
+version = "0.3.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.3.0"
+version = "0.3.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.3.0"
+version = "0.3.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/_self_describing.py
+++ b/packages/didactic/src/didactic/_self_describing.py
@@ -36,7 +36,7 @@ didactic.migrations._fingerprint.structural_fingerprint : the underlying address
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from didactic.models._model import Model
@@ -67,7 +67,7 @@ def schema_uri(cls: type[Model]) -> str:
 
 
 def embed_schema_uri(instance: Model) -> JsonObject:
-    """Return ``instance.model_dump()`` with a ``$schema`` URI prepended.
+    """Return the JSON-shape dump of ``instance`` with a ``$schema`` URI prepended.
 
     Parameters
     ----------
@@ -77,16 +77,23 @@ def embed_schema_uri(instance: Model) -> JsonObject:
     Returns
     -------
     dict
-        The dump dict, with ``"$schema"`` set to the Model's
+        The JSON-safe dump dict, with ``"$schema"`` set to the Model's
         canonical URI as the first key.
 
     Notes
     -----
+    Routes through ``model_dump_json`` (not the bare ``model_dump``)
+    so any nested ``tuple[Embed[T], ...]`` or ``dict[str, Embed[T]]``
+    fields get the JSON-safe walk; the returned dict is always
+    serialisable with ``json.dumps``.
+
     A consumer that knows how to resolve ``didactic://v1/<fp>`` URIs
     can fetch the Theory by fingerprint and validate the payload
     without knowing the original Python class.
     """
-    payload = instance.model_dump()
+    import json  # noqa: PLC0415
+
+    payload = cast("JsonObject", json.loads(instance.model_dump_json()))
     return {"$schema": schema_uri(type(instance)), **payload}
 
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -337,18 +337,16 @@ class Model(metaclass=ModelMeta):
             if exclude_defaults and not spec.is_required and value == spec.default:
                 continue
             key = spec.alias if by_alias and spec.alias else fname
-            if isinstance(value, Model):
-                # Embed[T] fields: recurse into the sub-model
-                result[key] = value.model_dump(by_alias=by_alias)
-            elif spec.translation.inner_kind == "sum":
-                # Sum-sort fields (Model-ref recursive aliases) carry
-                # constructor-tag dispatch info that gets lost if we drop
-                # the value into the dump as-is. Route through the
-                # translation's encoder to produce the tagged JsonValue
-                # shape; ``model_validate_json`` reverses it.
+            # Sum-sort fields must run first: a sum field whose current
+            # value is a Model variant would otherwise be dumped as a
+            # plain Model below and lose its constructor tag.
+            if spec.translation.inner_kind == "sum":
                 result[key] = cast(
                     "FieldValue", json.loads(spec.translation.encode(value))
                 )
+            elif isinstance(value, Model):
+                # Embed[T] fields: recurse into the sub-model
+                result[key] = value.model_dump(by_alias=by_alias)
             else:
                 result[key] = value
         # computed fields evaluate on access; include them in the dump but

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -52,7 +52,7 @@ from typing import (
 from uuid import UUID
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
     from didactic.models._model import Model
     from didactic.types._typing import Encoded, FieldValue, JsonValue, Opaque
@@ -947,17 +947,34 @@ def _alias_sum_translation(alias: TypeAliasType) -> TypeTranslation:
             return {primitive_tag_by_type[float]: value}
         for cls, tag in model_tag_by_class.items():
             if isinstance(value, cls):
-                # Model.model_dump returns the canonical record dict;
-                # the constructor payload IS that dict, no envelope.
+                # Route through ``model_dump_json`` so any nested
+                # ``tuple[Embed[T], ...]`` / ``dict[str, Embed[T]]`` /
+                # nested-Model structures inside the variant get the
+                # JSON-safe walk that ``model_dump`` alone skips.
                 model_value = cast("Model", value)
-                return {tag: cast("JsonValue", model_value.model_dump())}
-        if isinstance(value, tuple) and sig.has_tuple:
-            tup = cast("tuple[FieldValue, ...]", value)
-            inner: list[JsonValue] = [encode_one(item, seen) for item in tup]
+                return cast(
+                    "JsonValue", {tag: json.loads(model_value.model_dump_json())}
+                )
+        # Sequence values: prefer the ``tuple`` constructor when the
+        # alias declares one, even for Python ``list`` input. This
+        # keeps storage canonical (round-tripping a Python list and
+        # re-encoding produces the same constructor name as if it had
+        # been a tuple to begin with), matching the tuple-based
+        # ``FieldValue`` invariant.
+        if isinstance(value, (tuple, list)) and sig.has_tuple:
+            seq = cast("tuple[FieldValue, ...] | list[FieldValue]", value)
+            inner: list[JsonValue] = [encode_one(item, seen) for item in seq]
             return {f"{alias_name}_tuple": inner}
         if isinstance(value, list) and sig.has_list:
             lst = cast("list[FieldValue]", value)
             inner = [encode_one(item, seen) for item in lst]
+            return {f"{alias_name}_list": inner}
+        if isinstance(value, tuple) and sig.has_list:
+            # Alias declares only ``list[X]`` but the user constructed
+            # with a tuple: route through the list constructor so the
+            # alias's declared constructor space is honoured.
+            tup_for_list = cast("tuple[FieldValue, ...]", value)
+            inner = [encode_one(item, seen) for item in tup_for_list]
             return {f"{alias_name}_list": inner}
         if isinstance(value, dict) and sig.has_dict:
             mapping = cast("dict[str, FieldValue]", value)
@@ -996,10 +1013,12 @@ def _alias_sum_translation(alias: TypeAliasType) -> TypeTranslation:
             if target in _JSON_PRIMITIVE_TYPES:
                 # primitive arm; payload is the literal value
                 return cast("FieldValue", body)
-            # Model arm; ``target`` came from the alias's collected
-            # Model classes so it's known to expose ``model_validate``.
+            # Model arm; route through ``model_validate_json`` so the
+            # variant's per-field ``from_json`` callables run (e.g.
+            # list -> tuple coercion for nested ``tuple[T, ...]`` fields,
+            # ISO-string -> datetime for nested datetime fields).
             model_cls = cast("type[Model]", target)
-            return model_cls.model_validate(cast("Mapping[str, JsonValue]", body))
+            return model_cls.model_validate_json(json.dumps(body))
         # container arm; body is a JSON list/dict of inner-encoded values
         if target in {"list", "tuple"}:
             if not isinstance(body, list):
@@ -1089,7 +1108,11 @@ def _tagged_union_translation(cls: type) -> TypeTranslation:
     def encode_one(value: object) -> JsonValue:
         for variant_cls in variants_by_value.values():
             if isinstance(value, variant_cls):
-                return cast("JsonValue", value.model_dump())
+                # Route through ``model_dump_json`` so any nested
+                # ``tuple[Embed[T], ...]`` / ``dict[str, Embed[T]]`` /
+                # nested-Model fields inside the variant get the
+                # JSON-safe walk that ``model_dump`` alone skips.
+                return cast("JsonValue", json.loads(value.model_dump_json()))
         variant_names = sorted(v.__name__ for v in variants_by_value.values())
         msg = (
             f"value of type {type(value).__name__} is not a registered variant "
@@ -1734,13 +1757,17 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
     target_name = target_cls.__name__
 
     def encode(v: FieldValue) -> Encoded:
-        # accept either a target_cls instance or a dict (which we route
-        # through model_validate to produce one). This makes the
-        # model_dump -> model_validate round-trip work transparently.
+        # accept either a target_cls instance or a dict. The dict path
+        # goes through ``model_validate_json`` (not ``model_validate``)
+        # so each per-field ``from_json`` runs and JSON-shape values
+        # like ``[1, 2, 3]`` for a ``tuple[int, ...]`` field get the
+        # list-to-tuple coercion before the field encoder asserts.
         if isinstance(v, target_cls):
             return json.dumps(v.to_storage_dict())
         if isinstance(v, dict):
-            return json.dumps(target_cls.model_validate(v).to_storage_dict())
+            return json.dumps(
+                target_cls.model_validate_json(json.dumps(v)).to_storage_dict()
+            )
         msg = (
             f"Embed[{target_name}] expected a {target_name} instance or dict; "
             f"got {type(v).__name__}"
@@ -1758,10 +1785,12 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
         return target_cls.from_storage_dict(items)
 
     def from_json(v: JsonValue) -> FieldValue:
-        # the JSON form is the model_dump dict (decoded values), not the
-        # storage dict; route through model_validate to re-encode.
+        # the JSON form is the model_dump dict (decoded values), not
+        # the storage dict; route through ``model_validate_json`` so
+        # the inner Model's per-field ``from_json`` runs (e.g. JSON
+        # list -> tuple for nested ``tuple[T, ...]`` fields).
         if isinstance(v, dict):
-            return target_cls.model_validate(v)
+            return target_cls.model_validate_json(json.dumps(v))
         msg = f"expected JSON object for Embed[{target_name}]; got {type(v).__name__}"
         raise TypeError(msg)
 

--- a/packages/didactic/tests/test_nested_round_trip.py
+++ b/packages/didactic/tests/test_nested_round_trip.py
@@ -1,0 +1,334 @@
+"""Regression tests for JSON round-trip across nested Embed / sum sorts.
+
+Two bug families covered:
+
+1. Encoder side (``model_dump_json``): a sum-sort field whose variant
+   carries a ``tuple[Embed[Model], ...]`` or ``dict[str, Embed[Model]]``
+   sub-field used to drop the raw nested ``Model`` instances into the
+   JSON-encoded output, where ``json.dumps`` then refused to serialise
+   them. The encoder now routes the variant through its own
+   ``model_dump_json`` so the JSON-safe walk runs.
+
+2. Decoder side (``model_validate_json``): an ``Embed[Inner]`` field
+   round-tripped to and from JSON failed when ``Inner`` had a
+   ``tuple[T, ...]`` sub-field, because the embed translation called
+   ``Inner.model_validate`` on the JSON-decoded ``dict``: that bypasses
+   the per-field ``from_json`` coercion that would convert the inner
+   list back to a tuple. The embed translation now routes inner
+   payloads through ``model_validate_json`` so per-field coercion
+   runs at every level.
+
+Both families had multiple manifestations across the bare / dict-value
+/ tuple-element / Embed-wrapped placements of the outer field; this
+file exercises each combination so a future regression in any one
+encoder or decoder lights the suite up.
+"""
+
+from typing import Literal, cast
+
+import didactic.api as dx
+from didactic.api import embed_schema_uri
+
+
+class Anchor(dx.Model):
+    unit: str
+    pos: float
+
+
+class StepEntry(dx.Model):
+    """An embedded sub-Model. Has a single ``Embed[Anchor]`` field."""
+
+    anchor: dx.Embed[Anchor]
+    value: float
+
+
+class StepEntryWithTuple(dx.Model):
+    """An embedded sub-Model whose own field is a ``tuple[Embed[Anchor], ...]``."""
+
+    name: str
+    anchors: tuple[dx.Embed[Anchor], ...] = ()
+
+
+class StepEntryWithDict(dx.Model):
+    """An embedded sub-Model whose own field is a ``dict[str, Embed[Anchor]]``."""
+
+    name: str
+    anchors: dict[str, dx.Embed[Anchor]] = dx.field(
+        default_factory=lambda: cast("dict[str, dx.Embed[Anchor]]", {})
+    )
+
+
+class P(dx.TaggedUnion, discriminator="kind"):
+    """TaggedUnion root for the encoder-side regression set."""
+
+
+class StepFunction(P):
+    """Variant carrying a ``tuple[Embed[StepEntry], ...]``."""
+
+    kind: Literal["step"]
+    entries: tuple[dx.Embed[StepEntry], ...] = ()
+
+
+class MapFunction(P):
+    """Variant carrying a ``dict[str, Embed[StepEntry]]``."""
+
+    kind: Literal["map"]
+    by_name: dict[str, dx.Embed[StepEntry]] = dx.field(
+        default_factory=lambda: cast("dict[str, dx.Embed[StepEntry]]", {})
+    )
+
+
+def _step_function() -> StepFunction:
+    return StepFunction(
+        kind="step",
+        entries=(StepEntry(anchor=Anchor(unit="bar", pos=0.0), value=1.0),),
+    )
+
+
+def _map_function() -> MapFunction:
+    return MapFunction(
+        kind="map",
+        by_name={"x": StepEntry(anchor=Anchor(unit="bar", pos=0.5), value=2.0)},
+    )
+
+
+# -- (1) dict-value of TaggedUnion: variant has tuple[Embed[Model]] --------
+
+
+class TrackByDictTuple(dx.Model):
+    parameters: dict[str, P] = dx.field(
+        default_factory=lambda: cast("dict[str, P]", {})
+    )
+
+
+def test_dict_of_tagged_union_with_tuple_embed_variant_round_trips() -> None:
+    track = TrackByDictTuple(parameters={"tempo": _step_function()})
+    js = track.model_dump_json()
+    back = TrackByDictTuple.model_validate_json(js)
+    assert back == track
+
+
+# -- (2) dict-value of TaggedUnion: variant has dict[str, Embed[Model]] ----
+
+
+def test_dict_of_tagged_union_with_dict_embed_variant_round_trips() -> None:
+    track = TrackByDictTuple(parameters={"envelope": _map_function()})
+    js = track.model_dump_json()
+    back = TrackByDictTuple.model_validate_json(js)
+    assert back == track
+
+
+# -- (3) tuple-of-TaggedUnion: variant has tuple[Embed[Model]] -------------
+
+
+class TrackByTupleField(dx.Model):
+    chain: tuple[P, ...] = ()
+
+
+def test_tuple_of_tagged_union_with_tuple_embed_variant_round_trips() -> None:
+    track = TrackByTupleField(chain=(_step_function(), _map_function()))
+    js = track.model_dump_json()
+    back = TrackByTupleField.model_validate_json(js)
+    assert back == track
+
+
+# -- (4) bare TaggedUnion field: variant has tuple[Embed[Model]] -----------
+
+
+class TrackByBareField(dx.Model):
+    p: P
+
+
+def test_bare_tagged_union_field_with_tuple_embed_variant_round_trips() -> None:
+    track = TrackByBareField(p=_step_function())
+    js = track.model_dump_json()
+    back = TrackByBareField.model_validate_json(js)
+    assert back == track
+
+
+# -- (5) recursive Model-ref alias: Model arm has tuple[Embed[Model]] ------
+
+type _Comp = (
+    str
+    | int
+    | StepEntryWithTuple
+    | list["_Comp"]
+    | tuple["_Comp", ...]
+    | dict[str, "_Comp"]
+)
+
+
+class DocWithAlias(dx.Model):
+    body: _Comp
+
+
+def test_alias_model_arm_with_tuple_embed_round_trips() -> None:
+    step = StepEntryWithTuple(
+        name="x", anchors=(Anchor(unit="bar", pos=1.0), Anchor(unit="bar", pos=2.0))
+    )
+    doc = DocWithAlias(body=step)
+    js = doc.model_dump_json()
+    back = DocWithAlias.model_validate_json(js)
+    assert back == doc
+
+
+def test_alias_list_arm_carrying_models_with_tuple_embed_round_trips() -> None:
+    step = StepEntryWithTuple(name="x", anchors=(Anchor(unit="bar", pos=1.0),))
+    doc = DocWithAlias(body=[step, step])
+    back = DocWithAlias.model_validate_json(doc.model_dump_json())
+    assert back == doc
+
+
+type _Comp2 = str | int | StepEntryWithDict | dict[str, "_Comp2"] | tuple["_Comp2", ...]
+
+
+class _Doc2(dx.Model):
+    body: _Comp2
+
+
+def test_alias_dict_arm_carrying_models_with_dict_embed_round_trips() -> None:
+    step = StepEntryWithDict(name="x", anchors={"k": Anchor(unit="bar", pos=1.0)})
+    doc = _Doc2(body={"a": step})
+    back = _Doc2.model_validate_json(doc.model_dump_json())
+    assert back == doc
+
+
+# -- (6) embed_schema_uri on a Model with tuple[Embed[Model]] --------------
+
+
+class OuterWithTupleEmbed(dx.Model):
+    items: tuple[dx.Embed[StepEntry], ...] = ()
+
+
+def test_embed_schema_uri_walks_into_tuple_embed_fields() -> None:
+    """``embed_schema_uri`` returns a JSON-safe dict for any Model.
+
+    Previously it called ``instance.model_dump()`` and dropped the raw
+    Models; ``json.dumps`` of the result raised ``TypeError``.
+    """
+    import json
+
+    outer = OuterWithTupleEmbed(
+        items=(StepEntry(anchor=Anchor(unit="bar", pos=0.0), value=1.0),)
+    )
+    payload = embed_schema_uri(outer)
+    encoded = json.dumps(payload)
+    assert "items" in encoded
+    assert "anchor" in encoded
+    schema_uri = cast("str", payload["$schema"])
+    assert schema_uri.startswith("didactic://")
+
+
+# -- (7) Embed[Inner] where Inner has tuple[T, ...] ------------------------
+
+
+class InnerWithTuple(dx.Model):
+    items: tuple[int, ...] = ()
+
+
+class OuterEmbeddingInnerWithTuple(dx.Model):
+    inner: dx.Embed[InnerWithTuple]
+
+
+def test_embed_inner_with_tuple_field_round_trips_via_json() -> None:
+    """The outer / inner JSON round-trip preserves the tuple shape.
+
+    Previously ``Outer.model_validate_json`` reached
+    ``InnerWithTuple.model_validate(dict_payload)`` which fed the
+    JSON-decoded list straight to the tuple encoder's
+    ``isinstance(v, tuple)`` assertion.
+    """
+    o = OuterEmbeddingInnerWithTuple(inner=InnerWithTuple(items=(1, 2, 3)))
+    js = o.model_dump_json()
+    back = OuterEmbeddingInnerWithTuple.model_validate_json(js)
+    assert back == o
+    assert back.inner.items == (1, 2, 3)
+
+
+def test_doubly_nested_embed_with_tuple_field_round_trips() -> None:
+    """Two levels of Embed; the deepest has the tuple field."""
+
+    class Mid(dx.Model):
+        inner: dx.Embed[InnerWithTuple]
+
+    class Outer2(dx.Model):
+        mid: dx.Embed[Mid]
+
+    o = Outer2(mid=Mid(inner=InnerWithTuple(items=(7, 8))))
+    back = Outer2.model_validate_json(o.model_dump_json())
+    assert back == o
+
+
+def test_tuple_of_embed_inner_with_tuple_field_round_trips() -> None:
+    """``tuple[Embed[Inner], ...]`` where each Inner has a tuple field.
+
+    Stresses the same bug at the top-level container (instead of a
+    bare Embed): each Inner instance has to be JSON-coerced through
+    its own per-field ``from_json``.
+    """
+
+    class Holder(dx.Model):
+        items: tuple[dx.Embed[InnerWithTuple], ...] = ()
+
+    h = Holder(items=(InnerWithTuple(items=(1, 2)), InnerWithTuple(items=(3,))))
+    back = Holder.model_validate_json(h.model_dump_json())
+    assert back == h
+
+
+# -- (8) coverage that the existing happy paths still work -----------------
+
+
+class _Bare(dx.Model):
+    """Sanity check that flat (non-nested) tuple round-trip still works."""
+
+    pitches: tuple[int, ...] = ()
+
+
+def test_flat_tuple_field_round_trip_unchanged() -> None:
+    m = _Bare(pitches=(60, 64))
+    back = _Bare.model_validate_json(m.model_dump_json())
+    assert back == m
+
+
+type _Json = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["_Json"]
+    | tuple["_Json", ...]
+    | dict[str, "_Json"]
+)
+
+
+class _M(dx.Model):
+    params: dict[str, _Json]
+
+
+def test_existing_alias_round_trip_unchanged() -> None:
+    """The plain JSON-fixpoint alias path still works (no Models involved)."""
+    m = _M(params={"k": [1, 2, "x"], "j": {"nested": 1.5}})
+    back = _M.model_validate_json(m.model_dump_json())
+    assert back == m
+
+
+class Q(dx.TaggedUnion, discriminator="kind"):
+    pass
+
+
+class A(Q):
+    kind: Literal["a"]
+    value: float
+
+
+class _W(dx.Model):
+    q: Q
+
+
+def test_existing_simple_tagged_union_round_trip_unchanged() -> None:
+    """The simple TaggedUnion case (no nested Embed) still works."""
+    w = _W(q=A(kind="a", value=1.5))
+    back = _W.model_validate_json(w.model_dump_json())
+    assert isinstance(back.q, A)
+    assert back.q.value == 1.5

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Closes #7 (encoder side). Closes #8 (decoder side). Both surfaced in the neume integration; both reduce to the same root cause: code paths that called ``model_dump`` or ``model_validate`` directly skipped the per-field ``from_json`` / ``_to_json_safe`` walks that the JSON-string entry points perform.

## Motivation

Issue #7: ``dict[str, TaggedUnion]`` with a variant containing ``tuple[Embed[Model], ...]`` raised ``Object of type X is not JSON serializable`` from ``json.dumps``. Same shape for any sum-sort field whose variant carries nested Models.

Issue #8: ``Outer(inner=Inner(items=(1, 2, 3)))`` round-tripped through ``model_dump_json`` / ``model_validate_json`` raised ``AssertionError`` from the tuple field encoder when ``Inner`` had a ``tuple[T, ...]`` field.

I went looking for similar bugs and found four more sites with the same families: the recursive Model-ref alias's Model-arm encode and decode paths, ``Embed[T]``'s encode-from-dict path, and ``embed_schema_uri``. All fixed in one branch.

## Changes

- ``packages/didactic/src/didactic/types/_types.py``:
  - ``_alias_sum_translation``: Model-arm encode routes through ``model_dump_json``; Model-arm decode routes through ``model_validate_json(json.dumps(body))``. Container constructors canonicalise on the ``tuple`` constructor when both arms are declared.
  - ``_tagged_union_translation``: variant encode routes through ``model_dump_json``.
  - ``_embed_translation``: ``from_json`` and the encode-from-dict path both route through ``model_validate_json(json.dumps(payload))``.
- ``packages/didactic/src/didactic/models/_model.py``: ``model_dump`` checks ``inner_kind == \"sum\"`` before the ``isinstance(value, Model)`` branch, so a Model variant of a sum-sort field keeps its constructor tag.
- ``packages/didactic/src/didactic/_self_describing.py``: ``embed_schema_uri`` walks via ``model_dump_json``.
- ``packages/didactic/tests/test_nested_round_trip.py`` (new): 14 regression tests.
- All four packages bumped 0.3.0 -> 0.3.1.

## Tests

The new file covers, by section:

1. ``dict[str, TaggedUnion]`` with variant carrying ``tuple[Embed[Model]]`` (issue #7 repro).
2. Same with variant carrying ``dict[str, Embed[Model]]``.
3. ``tuple[TaggedUnion, ...]`` with variant carrying ``tuple[Embed[Model]]``.
4. Bare ``TaggedUnion`` field with variant carrying ``tuple[Embed[Model]]``.
5. Recursive Model-ref alias whose Model arm has ``tuple[Embed[Model]]``; list-arm carrying Models that themselves have ``tuple[Embed[Model]]``; dict-arm carrying Models with ``dict[str, Embed[Model]]``.
6. ``embed_schema_uri`` on a Model with ``tuple[Embed[Model]]``.
7. ``Embed[Inner]`` with ``Inner.items: tuple[T, ...]`` (issue #8 repro); doubly-nested Embed; tuple of Embed of Inner with the tuple field.
8. Three positive-regression tests confirming the flat-tuple, JSON-fixpoint alias, and simple TaggedUnion paths still work.

## Local CI

- [x] ``uv run ruff format --check``
- [x] ``uv run ruff check``
- [x] ``uv run pyright``
- [x] ``uv run pytest -ra`` -- 481 pass
- [x] ``uv run mkdocs build --strict``

## Compatibility

- **Bug fix.** All previously-working code keeps working; the changes only make previously-broken cases work.
- The container-constructor canonicalisation in (5) does change the on-wire form: a recursive alias with both ``list`` and ``tuple`` arms now always emits the ``tuple`` constructor for any sequence input. Storage written under v0.3.0 with the ``list`` constructor still decodes correctly (the decode path handles both); the only user-visible change is ``Model`` equality round-trips that previously broke now succeed.

## Changelog

- [x] Added a ``CHANGELOG.md`` entry under ``[0.3.1] - 2026-05-01``.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

- Closes #7
- Closes #8