### PR TITLE
feat(models): extra="ignore", generic auto-parameterise, inherited defaults (v0.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,6 @@ jobs:
       - run: uv python install 3.14
       - run: uv sync --all-packages --all-extras
       - name: build docs (strict)
+        env:
+          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
         run: uv sync --all-packages --all-extras
 
       - name: build site (strict)
+        env:
+          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict --site-dir site
 
       - name: configure pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
         run: uv run pytest -ra
 
       - name: docs build (strict)
+        env:
+          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,39 +13,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ``ModelConfig.extra="ignore"`` is honoured: keyword arguments at
   construction (and dict keys at ``model_validate``) that don't match
-  a declared field are silently dropped. ``with_()`` remains strict;
-  an unknown kwarg there is always a programming error. ([#11])
-- Generic Models auto-parameterise on subscript. ``class Range(dx.Model,
-  Generic[T]): min: T; max: T`` followed by ``Range[int](min=0, max=10)``
-  returns an instance of a synthesised concrete subclass. The
-  synthesised class is cached per type-arg tuple, so repeated
+  a declared field are silently dropped. ``with_()`` stays strict
+  regardless; an unknown kwarg there is always a programming error.
+  ([#11])
+- Generic Models auto-parameterise on subscript. Both PEP 695 syntax
+  (``class Range[T: int | float](dx.Model): ...``) and the legacy
+  ``Generic[T]`` mixin form work. ``Range[int](min=0, max=10)`` returns
+  an instance of a synthesised concrete subclass; the subclass is
+  cached per type-arg tuple on the generic parent so repeated
   subscripts return the same class object and its ``Theory`` is built
-  once. Only bare ``TypeVar`` annotations are substituted; nested
-  shapes (``items: tuple[T, ...]``) stay unsubstituted and raise the
-  existing ``TypeVar``-encode error. ([#12])
-- ``read_class_annotations`` is now part of the public surface
-  (lifted from the underscore-prefixed ``_read_class_annotations``)
-  and the metaclass's annotation-reader return type widens to
+  once. Substitution walks through nested generic shapes:
+  ``tuple[T, ...]``, ``dict[str, T]``, ``T | None``,
+  ``Annotated[T, *meta]``, ``Embed[T]``, ``Ref[T]``, and unions of
+  these are all rewritten correctly. Class-level defaults
+  (``min: T = 0``) and ``dx.field(...)`` metadata (``default``,
+  ``default_factory``, ``description``, ``alias``, ``examples``,
+  ``deprecated``, ``nominal``, ``usage_mode``, ``extras``,
+  ``converter``) propagate from the generic parent onto the
+  synthesised subclass. ([#12])
+- ``read_class_annotations`` is part of the public surface (lifted
+  from the underscore-prefixed ``_read_class_annotations``) and the
+  metaclass's annotation-reader return type is
   ``dict[str, type | TypeVar | ForwardRef]`` to reflect what the
-  PEP 695 generic-parameter path actually produces.
+  PEP 695 generic-parameter path produces.
 
 ### Fixed
 
-- Inherited field defaults are no longer dropped on subclass.
-  ``Child(Base)`` where ``Base`` declares ``id: str = "default-id"``
-  inherits the default. ``ModelMeta.collect_field_specs`` previously
-  re-read every annotation from ``klass.__dict__`` while walking the
-  MRO, but defaults are stripped from ``__dict__`` during the parent's
-  own class creation; the MRO walk now copies the parent's
-  already-finalised ``FieldSpec`` for inherited fields and only
-  re-builds specs for the target class's own annotations. ([#13])
+- Inherited field defaults survive on subclass. ``Child(Base)`` where
+  ``Base`` declares ``id: str = "default-id"`` constructs cleanly
+  with the inherited default. ``ModelMeta.collect_field_specs`` walks
+  ancestor classes by copying their already-finalised ``FieldSpec``;
+  it only re-runs ``_build_field_spec`` for the target class's own
+  annotations. (Reading ``__dict__`` for ancestor classes lost their
+  defaults because the metaclass strips field defaults from the
+  class dict at the end of each Model's class-creation step.) ([#13])
+- The deferred-TypeVar branch in ``_build_field_spec`` carries
+  through every ``Field`` attribute (default, default_factory,
+  converter, alias, description, examples, deprecated, nominal,
+  usage_mode, extras), so a generic with ``value: T = dx.field(default=42,
+  description="...")`` keeps that metadata available for
+  parameterisation.
 
 ### Removed
 
 - The leftover ``# Tracked in panproto/didactic#1.`` comment blocks
-  from ``didactic#1``'s suppression unwind are stripped. The blocks
-  documented suppressions that no longer exist; they were not
-  flagged in CI but accumulated as documentation rot.
+  from the v0.3.2 suppression unwind are stripped from every file in
+  the workspace. They documented suppressions that no longer exist.
 
 [#11]: https://github.com/panproto/didactic/issues/11
 [#12]: https://github.com/panproto/didactic/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-05
+
+### Added
+
+- ``ModelConfig.extra="ignore"`` is honoured: keyword arguments at
+  construction (and dict keys at ``model_validate``) that don't match
+  a declared field are silently dropped. ``with_()`` remains strict;
+  an unknown kwarg there is always a programming error. ([#11])
+- Generic Models auto-parameterise on subscript. ``class Range(dx.Model,
+  Generic[T]): min: T; max: T`` followed by ``Range[int](min=0, max=10)``
+  returns an instance of a synthesised concrete subclass. The
+  synthesised class is cached per type-arg tuple, so repeated
+  subscripts return the same class object and its ``Theory`` is built
+  once. Only bare ``TypeVar`` annotations are substituted; nested
+  shapes (``items: tuple[T, ...]``) stay unsubstituted and raise the
+  existing ``TypeVar``-encode error. ([#12])
+- ``read_class_annotations`` is now part of the public surface
+  (lifted from the underscore-prefixed ``_read_class_annotations``)
+  and the metaclass's annotation-reader return type widens to
+  ``dict[str, type | TypeVar | ForwardRef]`` to reflect what the
+  PEP 695 generic-parameter path actually produces.
+
+### Fixed
+
+- Inherited field defaults are no longer dropped on subclass.
+  ``Child(Base)`` where ``Base`` declares ``id: str = "default-id"``
+  inherits the default. ``ModelMeta.collect_field_specs`` previously
+  re-read every annotation from ``klass.__dict__`` while walking the
+  MRO, but defaults are stripped from ``__dict__`` during the parent's
+  own class creation; the MRO walk now copies the parent's
+  already-finalised ``FieldSpec`` for inherited fields and only
+  re-builds specs for the target class's own annotations. ([#13])
+
+### Removed
+
+- The leftover ``# Tracked in panproto/didactic#1.`` comment blocks
+  from ``didactic#1``'s suppression unwind are stripped. The blocks
+  documented suppressions that no longer exist; they were not
+  flagged in CI but accumulated as documentation rot.
+
+[#11]: https://github.com/panproto/didactic/issues/11
+[#12]: https://github.com/panproto/didactic/issues/12
+[#13]: https://github.com/panproto/didactic/issues/13
+
 ## [0.3.2] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ uv run pytest
 uv run ruff format
 uv run ruff check
 uv run pyright
-uv run mkdocs build --strict
+NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict
 ```
+
+The `NO_MKDOCS_2_WARNING` env var silences the marketing banner that
+the `mkdocs-material` package prints unconditionally to stderr; CI
+sets it for the same reason.
 
 CI runs lint, pyright, pytest, and the docs build on Linux and macOS
 for every PR.

--- a/docs/guide/generics.md
+++ b/docs/guide/generics.md
@@ -1,0 +1,184 @@
+# Generic Models
+
+A `dx.Model` subclass declared with type parameters synthesises a
+concrete subclass on subscript. `Range[int](min=0, max=10)` produces
+an instance of `Range[int]`, a real subclass cached per type-arg
+tuple, with the parent's `T`-typed fields rewritten to use `int`.
+
+## Declaring a generic Model
+
+PEP 695 syntax (recommended):
+
+```python
+import didactic.api as dx
+
+
+class Range[T: int | float](dx.Model):
+    min: T
+    max: T
+```
+
+Legacy `Generic[T]` mixin syntax also works:
+
+```python
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T", int, float)
+
+
+class Range(dx.Model, Generic[T]):
+    min: T
+    max: T
+```
+
+## Subscripting
+
+```python
+IntRange = Range[int]
+IntRange(min=0, max=10)
+# Range[int](min=0, max=10)
+```
+
+`Range[int]` returns a real subclass of `Range`. Repeated subscripts
+return the same class object:
+
+```python
+Range[int] is Range[int]   # True
+Range[int].__theory__      # built once, cached
+```
+
+The synthesised class participates in everything an explicit subclass
+would: `model_dump()`, `model_validate_json()`, lenses, axioms,
+codegen, `Repository.add(...)`. Its `__field_specs__` carries
+concrete sorts (e.g. `Int` for `int`, not the deferred `_TypeVar:T`
+placeholder).
+
+## Defaults and metadata propagate
+
+Defaults on the generic carry through to the synthesised subclass:
+
+```python
+class Range[T: int | float](dx.Model):
+    min: T = 0
+    max: T = 100
+
+
+Range[int]()
+# Range[int](min=0, max=100)
+```
+
+`dx.field(...)` metadata also propagates: `default`,
+`default_factory`, `description`, `alias`, `examples`, `deprecated`,
+`nominal`, `usage_mode`, `extras`, and `converter` all flow onto the
+synthesised subclass's spec.
+
+```python
+class Counter[T](dx.Model):
+    value: T = dx.field(default=0, description="a counter")
+
+
+Counter[int].__field_specs__["value"].description
+# 'a counter'
+```
+
+## Substitution through nested shapes
+
+The substitution walks through the common generic containers,
+unions, and `Annotated[...]`:
+
+```python
+from typing import Annotated
+from annotated_types import Ge
+
+
+class Items[T](dx.Model):
+    seq: tuple[T, ...] = ()
+    by_name: dict[str, T] = dx.field(default_factory=dict)
+    maybe: T | None = None
+    bounded: Annotated[T, Ge(0)] = 0
+```
+
+Each is rewritten correctly under subscript:
+
+| declared | after `Items[int]` |
+| --- | --- |
+| `tuple[T, ...]` | `tuple[int, ...]` |
+| `dict[str, T]` | `dict[str, int]` |
+| `T \| None` | `int \| None` |
+| `Annotated[T, Ge(0)]` | `Annotated[int, Ge(0)]` |
+
+The `Annotated[...]` metadata is preserved verbatim, so the
+``annotated-types`` axioms (`Ge`, `Le`, `MinLen`, etc.) continue to
+fire on the synthesised subclass.
+
+## Multiple type parameters
+
+```python
+class Pair[K, V](dx.Model):
+    key: K
+    value: V
+
+
+Pair[str, int](key="x", value=42)
+# Pair[str, int](key='x', value=42)
+```
+
+Arity must match: `Pair[int]` raises `TypeError`.
+
+## Subclassing a parameterised generic
+
+```python
+class IntTree(Range[int]):
+    label: str
+```
+
+`Range[int]` is a real class, so `IntTree` subclasses it normally.
+`IntTree.__field_specs__` contains `min`, `max`, and `label`.
+
+## What stays unsubstituted
+
+A bare `dx.Model` subclass passed as a type argument is not
+auto-wrapped in `Embed[T]` or `Ref[T]`. If you want the generic to
+hold an embedded sub-model, declare it explicitly:
+
+```python
+class Container[T](dx.Model):
+    item: dx.Embed[T]
+
+
+class Person(dx.Model):
+    name: str
+
+
+Container[Person](item=Person(name="alice"))
+```
+
+`Container[Person]` substitutes `Embed[T]` to `Embed[Person]`.
+
+## Constructing the unparameterised generic
+
+Constructing the bare generic without subscripting raises:
+
+```python
+Range(min=0, max=10)
+# ValidationError: cannot encode a TypeVar-annotated field; the class
+# is generic and must be parameterised before construction
+```
+
+The TypeVar guards on the original class stay in place; only the
+synthesised subclass has concrete sorts.
+
+## TypeVar constraints
+
+`TypeVar("T", int, float)` is enforced statically by your type checker
+but not at didactic runtime. `Range[str]` synthesises a class whose
+`min` field has sort `String`; the TypeVar's static `int | float`
+constraint is information for the type checker, not a runtime guard.
+
+## Cache lifetime
+
+The cache lives on the generic class as `__parameterised_cache__`. A
+synthesised subclass is held alive by the cache for as long as the
+generic class itself is reachable; if the generic class is garbage
+collected, the cache (and every entry) goes with it.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,6 +22,9 @@ specific question of the form "how do I do X with didactic".
   once at construction).
 - [Inheritance](inheritance.md) explains how `class B(A)` produces a
   panproto Theory colimit and how multi-inheritance behaves.
+- [Generic Models](generics.md) covers PEP 695 generic class syntax,
+  the `Generic[T]` mixin, subscript synthesis, default propagation,
+  and substitution through nested generic shapes.
 
 ## Validation
 

--- a/docs/guide/inheritance.md
+++ b/docs/guide/inheritance.md
@@ -34,6 +34,43 @@ flat Theory built from the merged spec; no colimit is involved.
 Inherited axioms (`__axioms__`) are also collected: `B` is checked
 against both its own and `A`'s.
 
+### Inherited defaults
+
+A subclass inherits the parent's defaults verbatim. Re-declaring a
+field on the subclass replaces the inherited spec; if the
+re-declaration omits a default, the field becomes required on the
+subclass (matching dataclass semantics).
+
+```python
+class Base(dx.Model):
+    id: str = "default-id"
+    name: str = "default-name"
+
+
+class Child(Base):
+    extra: str = "x"
+
+
+Child()
+# Child(id='default-id', name='default-name', extra='x')
+
+
+class Override(Base):
+    id: str = "child-id"   # replaces the parent's default
+    # name keeps the parent's "default-name"
+
+
+class Required(Base):
+    id: str   # no default re-declaration -> required
+
+
+Required()  # raises ValidationError: required field 'id' not supplied
+```
+
+The parent's `default_factory`, `description`, `alias`, `examples`,
+and other Field metadata flow through alongside the default. Each
+subclass instance still calls the factory fresh.
+
 ## Multi inheritance
 
 ```python

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -101,3 +101,43 @@ Every Model exposes:
 - `__computed_fields__`: the names of `@computed` properties.
 - `__theory__`: the lazily-built `panproto.Theory` (computed on
   first access).
+
+## Configuration
+
+Class-level configuration goes in [ModelConfig][didactic.api.ModelConfig],
+either as keyword arguments on the class header or as a
+`__model_config__` attribute on the class body. Both forms are
+equivalent; header keywords take precedence on conflict.
+
+```python
+class Strict(dx.Model, extra="forbid"):
+    """Default policy: an unknown keyword at construction raises."""
+    id: str
+
+
+class Lenient(dx.Model, extra="ignore"):
+    """Drops unknown keys at construction without raising."""
+    id: str
+```
+
+### `extra` policy
+
+| value | behaviour at construction |
+| --- | --- |
+| `"forbid"` (default) | unknown keys raise `ValidationError` with a `extra_field` entry |
+| `"ignore"` | unknown keys are silently dropped; they never enter storage and never appear in `model_dump()` |
+| `"allow"` | reserved; raises `NotImplementedError` at config construction |
+
+`"ignore"` is the right policy for a Model that ingests external
+payloads with vendor-specific or schema-evolved fields you don't want
+to enumerate. Round-trips are clean: dropped keys never resurrect.
+
+```python
+record = Lenient.model_validate({"id": "u1", "vendor_added": "telemetry"})
+record.model_dump()
+# {'id': 'u1'}    -- vendor_added is gone
+```
+
+`with_()` stays strict regardless of policy. Naming a field
+explicitly there is always a programming error; the lenient policy
+applies only to construction-from-external-data boundaries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
     - Validators: guide/validators.md
     - Axioms: guide/axioms.md
     - Inheritance: guide/inheritance.md
+    - Generic Models: guide/generics.md
     - Lenses: guide/lenses.md
     - Migrations: guide/migrations.md
     - Schema diff: guide/diff.md

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.3.2"
+version = "0.4.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.3.2"
+version = "0.4.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.3.2"
+version = "0.4.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.3.2"
+version = "0.4.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/codegen/_json_schema.py
+++ b/packages/didactic/src/didactic/codegen/_json_schema.py
@@ -1,6 +1,3 @@
-# ``annotated_metadata`` lives on ``spec.extras`` as ``Opaque`` and
-# the per-marker iteration takes the marker as an opaque value to
-# duck-type. Tracked in panproto/didactic#1.
 """JSON Schema (Draft 2020-12) generation from a Model class.
 
 The single user-facing entry point is

--- a/packages/didactic/src/didactic/fields/_derived.py
+++ b/packages/didactic/src/didactic/fields/_derived.py
@@ -42,12 +42,6 @@ See Also
 didactic.computed : evaluated every read; not cached.
 """
 
-# Reaches into ``Model._derived_cache`` (a documented Model-internal
-# slot) from a closure attached to the @derived decorator. The
-# ``_`` prefix is conventional for "implementation detail of the
-# Model layer"; the derived-decorator integration is part of that
-# layer. Tracked in panproto/didactic#1.
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/packages/didactic/src/didactic/fields/_unions.py
+++ b/packages/didactic/src/didactic/fields/_unions.py
@@ -1,7 +1,3 @@
-# ``TaggedUnion.model_validate`` overrides the base class with a
-# narrower payload type; the runtime accepts the base shape too. The
-# ``Literal[...]`` discriminator extraction goes through annotation
-# walking that pyright can't follow. Tracked in panproto/didactic#1.
 """Tagged (discriminated) unions over [Model][didactic.api.Model] subclasses.
 
 Pydantic-shaped discriminated unions: declare a base class with a

--- a/packages/didactic/src/didactic/migrations/_diff.py
+++ b/packages/didactic/src/didactic/migrations/_diff.py
@@ -1,6 +1,3 @@
-# ``diff_and_classify`` returns a ``CompatReport`` whose ``.to_dict()``
-# we re-emit as ``JsonObject``; pyright's stub doesn't narrow the
-# panproto-side types tightly enough. Tracked in panproto/didactic#1.
 """Schema diff and breaking-change detection.
 
 Two thin functions over panproto's ``diff_schemas`` and

--- a/packages/didactic/src/didactic/migrations/_fingerprint.py
+++ b/packages/didactic/src/didactic/migrations/_fingerprint.py
@@ -1,7 +1,3 @@
-# ``structural_spec`` and friends shape ``TheorySpec`` (a TypedDict)
-# back into ``JsonObject`` (``dict[str, JsonValue]``); the dict
-# invariance bites. ``_default`` narrowing on tuple inputs is
-# pyright-flagged as redundant. Tracked in panproto/didactic#1.
 """Stable fingerprints for didactic Theory specs.
 
 didactic stores migration registry entries by a fingerprint that is

--- a/packages/didactic/src/didactic/models/_config.py
+++ b/packages/didactic/src/didactic/models/_config.py
@@ -46,8 +46,13 @@ class ModelConfig:
     ----------
     extra
         How to handle keyword arguments that don't match a declared
-        field. Only ``"forbid"`` is honoured currently; ``"ignore"`` and
-        ``"allow"`` raise ``NotImplementedError``.
+        field. ``"forbid"`` (default) raises ``ValidationError`` on
+        any unknown key; ``"ignore"`` silently drops unknown keys at
+        construction (the dropped values never enter the model and
+        never appear in ``model_dump()``). ``"allow"`` raises
+        ``NotImplementedError`` (it needs a storage decision for
+        unknown fields that the immutable Model contract doesn't
+        cleanly support yet).
     strict
         If ``True``, type coercion is disabled; every field's value
         must already be the declared type. Default ``True``. ``False``
@@ -75,11 +80,16 @@ class ModelConfig:
                 f"got {self.extra!r}"
             )
             raise ValueError(msg)
-        # v0.0.1 only honours `forbid`; fail loud on the unsupported settings
-        if self.extra != "forbid":
+        # ``"forbid"`` and ``"ignore"`` are honoured at construction
+        # (in ``Model.__init__``). ``"allow"`` is reserved: storing
+        # unknown values where ``model_dump`` can find them while
+        # keeping the model frozen has no settled design.
+        if self.extra == "allow":
             msg = (
-                f"ModelConfig.extra={self.extra!r} is not yet implemented; "
-                "only 'forbid' is honoured."
+                "ModelConfig.extra='allow' is not yet implemented; the "
+                "frozen-Model contract has no settled storage path for "
+                "unknown fields. Use 'ignore' to drop them silently or "
+                "'forbid' to reject them."
             )
             raise NotImplementedError(msg)
         if not self.strict:

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -25,7 +25,14 @@ from __future__ import annotations
 import annotationlib
 import contextlib
 import sys
-from typing import TYPE_CHECKING, ForwardRef, TypeVar, cast, dataclass_transform
+from typing import (
+    TYPE_CHECKING,
+    ForwardRef,
+    TypeVar,
+    cast,
+    dataclass_transform,
+    get_args,
+)
 
 from didactic.axioms._axioms import collect_class_axioms
 from didactic.fields._computed import computed_field_names
@@ -92,6 +99,26 @@ def _deferred_from_json(_: JsonValue) -> FieldValue:
         "generic and must be parameterised before any value can round-trip"
     )
     raise TypeError(msg)
+
+
+def _annotation_contains_typevar(annotation: object, depth: int = 0) -> bool:
+    """Return True iff ``annotation`` contains a ``TypeVar`` anywhere in its shape.
+
+    Walks parameterised generics (``list[T]``, ``tuple[T, ...]``,
+    ``dict[str, T]``, ``Embed[T]``, ``Annotated[T, ...]``, unions of
+    these) and stops at the first ``TypeVar`` leaf. Depth-bounded so
+    pathological recursive aliases don't loop forever.
+    """
+    if depth > 64:
+        return False
+    if isinstance(annotation, TypeVar):
+        return True
+    args = get_args(annotation)
+    if not args:
+        return False
+    return any(
+        a is not Ellipsis and _annotation_contains_typevar(a, depth + 1) for a in args
+    )
 
 
 def read_class_annotations(cls: type) -> dict[str, type | TypeVar | ForwardRef]:
@@ -199,6 +226,12 @@ def _build_field_spec(
         and annotation.__forward_arg__.isupper()
     ):
         tv_name = annotation.__forward_arg__
+    elif _annotation_contains_typevar(annotation):
+        # Nested TypeVar (e.g. ``items: tuple[T, ...]`` or
+        # ``by_name: dict[str, T]``). Defer the same way as a bare
+        # TypeVar; ``Model.__class_getitem__`` substitutes through
+        # the nested shape on parameterisation.
+        tv_name = "<nested>"
     if tv_name is not None:
         from didactic.types._types import TypeTranslation  # noqa: PLC0415
 
@@ -209,11 +242,32 @@ def _build_field_spec(
             inner_kind="generic",
             from_json=_deferred_from_json,
         )
+        # If the user supplied ``f: T = dx.field(default=..., description=...)``
+        # the Field descriptor's metadata must survive on the deferred spec
+        # so a parameterised subclass can propagate the default and metadata
+        # onto its own (concrete-annotation) FieldSpec. Plain values land in
+        # ``default`` directly.
+        if isinstance(raw_default, Field):
+            return FieldSpec(
+                name=name,
+                annotation=annotation,
+                translation=deferred,
+                default=raw_default.default,
+                default_factory=raw_default.default_factory,
+                converter=raw_default.converter,
+                alias=raw_default.alias,
+                description=raw_default.description,
+                examples=raw_default.examples,
+                deprecated=raw_default.deprecated,
+                nominal=raw_default.nominal,
+                usage_mode=raw_default.usage_mode,
+                extras=dict(raw_default.extras) if raw_default.extras else {},
+            )
         return FieldSpec(
             name=name,
             annotation=annotation,
             translation=deferred,
-            default=raw_default if not isinstance(raw_default, Field) else MISSING,
+            default=raw_default,
             usage_mode="readwrite",
         )
     # Above branches return for ``TypeVar`` / ``ForwardRef`` cases; the
@@ -462,11 +516,10 @@ class ModelMeta(type):
         # (defaults captured during their own construction); copy the
         # spec verbatim. For ``target`` itself we re-run
         # ``_build_field_spec`` because the raw default still lives on
-        # the class dict and hasn't been replaced by the descriptor yet.
-        # Reading ``__dict__`` for ancestor classes would lose their
-        # defaults, since a Model's class-attribute defaults are
-        # consumed at class-creation time and no longer present in
-        # ``__dict__`` afterwards.
+        # the class dict and hasn't been stripped yet. Reading
+        # ``__dict__`` for ancestor classes would surface no default,
+        # because the metaclass strips field defaults from the class
+        # dict at the end of each Model's class-creation step.
         for klass in reversed(target.__mro__):
             if not isinstance(klass, ModelMeta):
                 continue

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -1,10 +1,3 @@
-# The metaclass passes resolved annotations (``type | TypeVar |
-# ForwardRef``) into ``classify`` and ``_build_field_spec``, which
-# expect the narrower ``TypeForm`` (``type | UnionType``). The
-# runtime contract handles the wider input (the metaclass also
-# accepts string forward refs and TypeVar instances), but pyright
-# can't follow the case split through the dataclass_transform
-# layer. Tracked in panproto/didactic#1.
 """The ``ModelMeta`` metaclass: class-as-Theory derivation.
 
 ``ModelMeta`` runs at class-creation time. It reads each annotated field,
@@ -101,7 +94,7 @@ def _deferred_from_json(_: JsonValue) -> FieldValue:
     raise TypeError(msg)
 
 
-def _read_class_annotations(cls: type) -> dict[str, type | ForwardRef]:
+def read_class_annotations(cls: type) -> dict[str, type | TypeVar | ForwardRef]:
     """Read a class's annotations through ``annotationlib``, robustly.
 
     Parameters
@@ -147,7 +140,7 @@ def _read_class_annotations(cls: type) -> dict[str, type | ForwardRef]:
     localns: dict[str, Opaque] = dict(vars(cls))
     localns.setdefault(cls.__name__, cls)
 
-    resolved: dict[str, type | ForwardRef] = {}
+    resolved: dict[str, type | TypeVar | ForwardRef] = {}
     for name, ann in raw.items():
         if isinstance(ann, str):
             try:
@@ -464,17 +457,34 @@ class ModelMeta(type):
         """
         seen: dict[str, FieldSpec] = {}
 
-        # walk MRO in reverse so derived classes overwrite base entries
+        # walk MRO in reverse so derived classes overwrite base entries.
+        # For ancestor classes the FieldSpec is already finalised
+        # (defaults captured during their own construction); copy the
+        # spec verbatim. For ``target`` itself we re-run
+        # ``_build_field_spec`` because the raw default still lives on
+        # the class dict and hasn't been replaced by the descriptor yet.
+        # Reading ``__dict__`` for ancestor classes would lose their
+        # defaults, since a Model's class-attribute defaults are
+        # consumed at class-creation time and no longer present in
+        # ``__dict__`` afterwards.
         for klass in reversed(target.__mro__):
             if not isinstance(klass, ModelMeta):
                 continue
-            anns = _read_class_annotations(klass)
-            for fname, ann in anns.items():
-                # skip private / dunder attributes
-                if fname.startswith("_"):
+            if klass is target:
+                anns = read_class_annotations(klass)
+                for fname, ann in anns.items():
+                    if fname.startswith("_"):
+                        continue
+                    raw_default = klass.__dict__.get(fname, MISSING)
+                    seen[fname] = _build_field_spec(fname, ann, raw_default)
+            else:
+                ancestor_specs = getattr(klass, "__field_specs__", None)
+                if ancestor_specs is None:
                     continue
-                raw_default = klass.__dict__.get(fname, MISSING)
-                seen[fname] = _build_field_spec(fname, ann, raw_default)
+                for fname, spec in ancestor_specs.items():
+                    if fname.startswith("_"):
+                        continue
+                    seen[fname] = spec
 
         return seen
 

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -28,10 +28,21 @@ from __future__ import annotations
 import json
 from datetime import date, datetime, time
 from decimal import Decimal
-from typing import TYPE_CHECKING, ClassVar, Self, TypeVar, cast
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    ClassVar,
+    Self,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 from uuid import UUID
 
-from didactic.fields._fields import MissingType
+from didactic.fields._fields import MISSING, Field, MissingType
 from didactic.fields._validators import (
     ValidationError,
     ValidationErrorEntry,
@@ -757,13 +768,9 @@ def _parameterise(cls: type[Model], params: object) -> type[Model]:
     base_anns = read_class_annotations(cls)
     new_anns: dict[str, object] = {}
     for fname, ann in base_anns.items():
-        # The annotationlib reader's static return type is
-        # ``type | ForwardRef``; PEP 695 ``Generic[T]`` produces
-        # ``TypeVar`` instances at runtime, so the isinstance check
-        # narrows correctly even though pyright thinks it can't fire.
-        ann_obj: object = ann
-        if isinstance(ann_obj, TypeVar) and ann_obj in substitution:
-            new_anns[fname] = substitution[ann_obj]
+        substituted = _substitute_typevars(ann, substitution)
+        if substituted is not ann:
+            new_anns[fname] = substituted
     if not new_anns:
         return _fallback_subscript(cls, params_tuple)
 
@@ -774,9 +781,141 @@ def _parameterise(cls: type[Model], params: object) -> type[Model]:
         "__module__": cls.__module__,
         "__qualname__": new_name,
     }
+    # Propagate every parent FieldSpec's default and metadata onto the
+    # synthesised class so the metaclass's MRO walk sees them as
+    # own-class defaults. Without this stamp, the substituted-annotation
+    # re-build sees raw_default=MISSING for the synth class and treats
+    # the field as required.
+    parent_specs: dict[str, FieldSpec] = getattr(cls, "__field_specs__", {})
+    for fname in new_anns:
+        spec = parent_specs.get(fname)
+        if spec is None:
+            continue
+        descriptor = _field_descriptor_from_spec(spec)
+        # MISSING is the sentinel meaning "no default and no metadata
+        # to propagate"; the field stays required on the synthesised
+        # class. Any other value (including ``None``) IS the default.
+        if descriptor is not MISSING:
+            namespace[fname] = descriptor
     new_cls = cast("type[Model]", type(new_name, (cls,), namespace))
     cache[params_tuple] = new_cls
     return new_cls
+
+
+def _substitute_typevars(
+    annotation: object, substitution: dict[TypeVar, object]
+) -> object:
+    """Substitute ``TypeVar`` leaves in ``annotation`` against ``substitution``.
+
+    Walks through nested generic shapes and returns a new annotation
+    with every ``TypeVar`` replaced by its concrete type. Returns the
+    original ``annotation`` object when no substitution applies, so
+    callers can use identity comparison to detect changes.
+
+    Handled shapes:
+
+    - bare ``TypeVar`` -> the substitution target.
+    - parameterised generic (``list[T]``, ``tuple[T, U]``,
+      ``tuple[T, ...]``, ``dict[str, T]``, ``frozenset[T]``,
+      ``Embed[T]``, ``Ref[T]``, ``Annotated[T, ...]``, etc.) -> the
+      origin re-subscripted with substituted args.
+    - union (``T | int``, ``Union[T, str]``) -> a new union with each
+      arm substituted.
+    - non-generic types and ``ForwardRef`` -> returned as-is.
+
+    Recursion bottoms out at non-substitutable leaves (real types,
+    forward references, primitive literals).
+    """
+    # bare TypeVar leaf
+    if isinstance(annotation, TypeVar):
+        return substitution.get(annotation, annotation)
+
+    args = get_args(annotation)
+    if not args:
+        return annotation
+
+    new_args = tuple(_substitute_typevars(a, substitution) for a in args)
+    if new_args == args:
+        return annotation
+
+    origin = get_origin(annotation)
+    # PEP 604 / typing union: rebuild via ``typing.Union[(...)]`` which
+    # accepts a tuple of arms and produces the appropriate union form.
+    # Ruff prefers ``X | Y``, but that can't be expressed for a runtime
+    # tuple of arms; ``noqa: UP007`` keeps the dynamic form.
+    if origin in {Union, UnionType}:
+        return Union[new_args]  # noqa: UP007
+    # ``Annotated[T, *meta]`` keeps its metadata tuple. Pyright's
+    # static check on ``Annotated[<dynamic-tuple>]`` requires the args
+    # to be statically known. Route through ``typing._SpecialForm``'s
+    # subscript via the standard ``[...]`` syntax wrapped in ``cast``
+    # to a plain subscriptable; the runtime construction works because
+    # ``obj[a, b, c]`` is sugar for ``obj.__getitem__((a, b, c))``.
+    if origin is Annotated:
+        meta = args[1:]
+        new_base = new_args[0]
+        if new_base is args[0]:
+            return annotation
+        # ``Annotated`` is a ``typing._SpecialForm`` whose ``__getitem__``
+        # accepts a tuple ``(base, *meta)``. The subscript syntax compiles
+        # to that call exactly; pyright doesn't model the special form, so
+        # cast to a subscriptable proxy.
+        annotated_subscript: object = Annotated
+        return cast("object", annotated_subscript[(new_base, *meta)])  # type: ignore[index]
+    # Generic alias: re-subscript the origin with the new args.
+    # ``tuple[T, ...]`` keeps the Ellipsis sentinel verbatim because
+    # ``Ellipsis`` is not a TypeVar (substitution returns it unchanged).
+    if origin is None:
+        return annotation
+    if not new_args:
+        return annotation
+    try:
+        return origin[new_args[0]] if len(new_args) == 1 else origin[new_args]
+    except TypeError:
+        return annotation
+
+
+def _field_descriptor_from_spec(spec: FieldSpec) -> object:
+    """Reconstruct a ``Field`` descriptor (or bare default) from a ``FieldSpec``.
+
+    Used by ``_parameterise`` to propagate a generic-parent's defaults
+    and metadata onto the synthesised concrete subclass. Returns the
+    sentinel ``MISSING`` when the parent spec carried neither a
+    default nor any metadata that needs to round-trip through
+    ``Field``: in that case the field stays required on the
+    synthesised class, matching the parent's behaviour. Otherwise
+    returns either the bare default value (for plain ``f: T = 0``)
+    or a fully-populated ``Field`` descriptor (for any spec carrying
+    metadata beyond a default).
+    """
+    has_default = spec.default is not MISSING
+    has_factory = spec.default_factory is not None
+    has_metadata = bool(
+        spec.alias
+        or spec.description
+        or spec.examples
+        or spec.deprecated
+        or spec.nominal
+        or spec.converter
+        or spec.usage_mode != "readwrite"
+        or spec.extras
+    )
+    if not (has_default or has_factory or has_metadata):
+        return MISSING
+    if has_default and not has_metadata and not has_factory:
+        return spec.default
+    return Field(
+        default=spec.default,
+        default_factory=spec.default_factory,
+        converter=spec.converter,
+        alias=spec.alias,
+        description=spec.description,
+        examples=spec.examples,
+        deprecated=spec.deprecated,
+        nominal=spec.nominal,
+        usage_mode=spec.usage_mode,
+        extras=dict(spec.extras) if spec.extras else None,
+    )
 
 
 def _fallback_subscript(cls: type[Model], params: object) -> type[Model]:
@@ -813,7 +952,7 @@ def _fallback_subscript(cls: type[Model], params: object) -> type[Model]:
     raise TypeError(msg)
 
 
-def _to_json_safe(value: FieldValue | JsonValue) -> JsonValue:  # noqa: PLR0911
+def _to_json_safe(value: FieldValue | JsonValue) -> JsonValue:
     """Recursively coerce a decoded value into a JSON-encodable form.
 
     Parameters

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 from datetime import date, datetime, time
 from decimal import Decimal
-from typing import TYPE_CHECKING, ClassVar, Self, cast
+from typing import TYPE_CHECKING, ClassVar, Self, TypeVar, cast
 from uuid import UUID
 
 from didactic.fields._fields import MissingType
@@ -36,7 +36,7 @@ from didactic.fields._validators import (
     ValidationError,
     ValidationErrorEntry,
 )
-from didactic.models._meta import ModelMeta
+from didactic.models._meta import ModelMeta, read_class_annotations
 from didactic.models._storage import DictStorage
 
 if TYPE_CHECKING:
@@ -89,6 +89,42 @@ class Model(metaclass=ModelMeta):
     __field_specs__: ClassVar[dict[str, FieldSpec]] = {}
     __computed_fields__: ClassVar[frozenset[str]] = frozenset()
     __class_axioms__: ClassVar[tuple[Axiom, ...]] = ()
+
+    def __class_getitem__(cls, params: object) -> type[Model]:
+        """Auto-parameterise a generic Model on subscript.
+
+        ``Range[int]`` returns a concrete subclass of ``Range`` whose
+        ``T``-typed fields use ``int``. The synthesised class is
+        cached per ``cls`` and per type-arg tuple, so repeated
+        subscripts return the same class object (and that class's
+        ``Theory`` is built once).
+
+        Falls back to typing's machinery when ``cls`` declares no
+        ``TypeVar`` field annotations to substitute (the subscript
+        becomes a structural ``_GenericAlias`` for type checkers
+        only, no runtime synthesis).
+
+        Parameters
+        ----------
+        params
+            A type or a tuple of types matching the class's
+            ``__parameters__`` arity.
+
+        Returns
+        -------
+        type
+            A synthesised concrete subclass when at least one field
+            annotation can be substituted; otherwise the upstream
+            ``_GenericAlias``.
+
+        Notes
+        -----
+        Only bare ``TypeVar`` annotations are substituted. Annotations
+        that contain a ``TypeVar`` nested inside a generic shape
+        (e.g. ``items: tuple[T, ...]``) stay unsubstituted and
+        surface the existing ``TypeVar``-encode error.
+        """
+        return _parameterise(cls, params)
 
     def __init__(self, **kwargs: FieldValue | JsonValue) -> None:
         """Construct a Model from keyword arguments.
@@ -153,8 +189,14 @@ class Model(metaclass=ModelMeta):
         from didactic.fields._derived import derived_field_names  # noqa: PLC0415
 
         derived_names = derived_field_names(cls)
+        # ``extra="ignore"`` silently drops unknown kwargs at construction.
+        # ``with_()`` stays strict regardless: an unknown kwarg there is
+        # always a programming error (see ``Model.with_``).
+        ignore_extra = cls.__model_config__.extra == "ignore"
         for k in kwargs:
             if k in specs or k in computed_names or k in derived_names:
+                continue
+            if ignore_extra:
                 continue
             errors.append(
                 ValidationErrorEntry(
@@ -679,6 +721,96 @@ class Model(metaclass=ModelMeta):
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
+
+def _parameterise(cls: type[Model], params: object) -> type[Model]:
+    """Synthesise (or fetch from cache) a concrete subclass of a generic ``cls``.
+
+    Implementation of ``Model.__class_getitem__``; lifted to a
+    module-level function so the static-type narrowing of ``params``
+    isn't trapped behind a class scope's restricted self/cls vocabulary.
+    """
+    params_tuple: tuple[object, ...] = (
+        cast("tuple[object, ...]", params) if isinstance(params, tuple) else (params,)
+    )
+
+    typevars: tuple[TypeVar, ...] = cast(
+        "tuple[TypeVar, ...]", getattr(cls, "__parameters__", ())
+    )
+    if not typevars or len(typevars) != len(params_tuple):
+        return _fallback_subscript(cls, params_tuple)
+
+    cache: dict[tuple[object, ...], type[Model]] | None = cls.__dict__.get(
+        "__parameterised_cache__"
+    )
+    if cache is None:
+        cache = {}
+        # ``setattr`` rather than direct assignment so the metaclass's
+        # frozen-class guard doesn't fire on this private bookkeeping
+        # attribute (it's not in ``__field_specs__``).
+        cls.__parameterised_cache__ = cache  # type: ignore[attr-defined]
+    cached = cache.get(params_tuple)
+    if cached is not None:
+        return cached
+
+    substitution: dict[TypeVar, object] = dict(zip(typevars, params_tuple, strict=True))
+    base_anns = read_class_annotations(cls)
+    new_anns: dict[str, object] = {}
+    for fname, ann in base_anns.items():
+        # The annotationlib reader's static return type is
+        # ``type | ForwardRef``; PEP 695 ``Generic[T]`` produces
+        # ``TypeVar`` instances at runtime, so the isinstance check
+        # narrows correctly even though pyright thinks it can't fire.
+        ann_obj: object = ann
+        if isinstance(ann_obj, TypeVar) and ann_obj in substitution:
+            new_anns[fname] = substitution[ann_obj]
+    if not new_anns:
+        return _fallback_subscript(cls, params_tuple)
+
+    arg_names = ", ".join(getattr(p, "__name__", str(p)) for p in params_tuple)
+    new_name = f"{cls.__name__}[{arg_names}]"
+    namespace: dict[str, object] = {
+        "__annotations__": new_anns,
+        "__module__": cls.__module__,
+        "__qualname__": new_name,
+    }
+    new_cls = cast("type[Model]", type(new_name, (cls,), namespace))
+    cache[params_tuple] = new_cls
+    return new_cls
+
+
+def _fallback_subscript(cls: type[Model], params: object) -> type[Model]:
+    """Defer a non-synthesisable ``cls[params]`` to typing's machinery.
+
+    When ``cls`` declares no ``Generic[...]`` parameters, or when
+    ``params`` doesn't substitute any of its TypeVar field
+    annotations, the subscript falls through here. ``Generic`` (if
+    present in the MRO) returns a ``_GenericAlias`` for the static
+    type checker; otherwise typing raises ``TypeError``.
+    """
+    # Walk the MRO past ``Model`` itself to find an ancestor's
+    # ``__class_getitem__`` (typically ``Generic.__class_getitem__``
+    # when the user wrote ``class Foo(dx.Model, Generic[T]): ...``).
+    # If no ancestor defines it, raise the same error typing would
+    # have raised for a non-generic class.
+    for base in cls.__mro__:
+        if base is Model:
+            continue
+        descriptor = base.__dict__.get("__class_getitem__")
+        if descriptor is None:
+            continue
+        # The descriptor is a classmethod (Generic), classmethod_descriptor
+        # (object), or function. ``__get__(None, cls)`` rebinds it to
+        # ``cls`` so the call invokes ``base.__class_getitem__(cls, params)``
+        # with ``cls`` as the receiver, matching the lookup ``cls[params]``
+        # would have produced if ``Model`` were not in the MRO.
+        rebound = descriptor.__get__(None, cls)
+        return cast("type[Model]", rebound(params))
+    msg = (
+        f"{cls.__name__!r} does not declare any ``Generic[...]`` "
+        "type parameters; subscripting is not supported."
+    )
+    raise TypeError(msg)
 
 
 def _to_json_safe(value: FieldValue | JsonValue) -> JsonValue:  # noqa: PLR0911

--- a/packages/didactic/tests/test_config.py
+++ b/packages/didactic/tests/test_config.py
@@ -42,9 +42,12 @@ def test_kwarg_overrides_attribute() -> None:
     assert Both.__model_config__.title == "kwarg-wins"
 
 
-def test_unsupported_extra_raises() -> None:
-    with pytest.raises(NotImplementedError, match="not yet implemented"):
-        dx.ModelConfig(extra="ignore")
+def test_extra_allow_raises() -> None:
+    """``extra="allow"`` is rejected at config construction.
+
+    The frozen-Model contract has no settled storage path for unknown
+    fields; ``"allow"`` is reserved until that's resolved.
+    """
     with pytest.raises(NotImplementedError, match="not yet implemented"):
         dx.ModelConfig(extra="allow")
 
@@ -85,3 +88,90 @@ def test_inheritance_carries_config() -> None:
 
     # child inherits the parent's config when none is specified
     assert Child.__model_config__.title == "Base"
+
+
+# -- extra="ignore" --------------------------------------------------------
+
+
+class _Strict(dx.Model):
+    """Default ``extra="forbid"`` model for negative-test contrast."""
+
+    known: int = 0
+
+
+class _Lenient(dx.Model, extra="ignore"):
+    """Drops unknown kwargs at construction; still strict for declared fields."""
+
+    known: int = 0
+
+
+def test_extra_forbid_rejects_unknown_kwarg() -> None:
+    with pytest.raises(dx.ValidationError) as exc:
+        _Strict.model_validate({"known": 1, "unknown": 2})
+    assert any(e.type == "extra_field" for e in exc.value.entries)
+
+
+def test_extra_ignore_accepts_unknown_kwarg() -> None:
+    """``extra="ignore"`` constructs successfully; unknown kwargs are dropped."""
+    instance = _Lenient.model_validate({"known": 1, "unknown": 2, "also_unknown": "x"})
+    assert instance.known == 1
+
+
+def test_extra_ignore_drops_unknowns_from_dump() -> None:
+    """Dropped kwargs never enter storage and never appear in model_dump."""
+    instance = _Lenient.model_validate({"known": 1, "unknown": 2})
+    payload = instance.model_dump()
+    assert "unknown" not in payload
+    assert payload == {"known": 1}
+
+
+def test_extra_ignore_round_trips_via_model_validate() -> None:
+    """``model_validate`` of an external dict drops unknown keys."""
+    instance = _Lenient.model_validate({"known": 7, "vendor_added": "telemetry"})
+    assert instance.known == 7
+    assert instance.model_dump() == {"known": 7}
+    # round-trip through dump and reload sees no resurrected unknown
+    again = _Lenient.model_validate(instance.model_dump())
+    assert again == instance
+
+
+def test_extra_ignore_with_method_still_strict() -> None:
+    """``with_()`` rejects unknown kwargs even when ``extra="ignore"``.
+
+    Naming a field explicitly in ``with_`` is always a programming
+    error; the lenient policy applies only at construction-from-
+    external-data boundaries. Unpack from a dict so the unknown
+    kwarg name slips past the static check the runtime guard tests.
+    """
+    instance = _Lenient(known=1)
+    # ``with_`` is statically typed; a dynamically-built kwargs dict
+    # bypasses the keyword-name check the runtime guard tests.
+    from didactic.types._typing import FieldValue  # noqa: PLC0415
+
+    bad_kwargs: dict[str, FieldValue] = {"unknown": 2}
+    with pytest.raises(dx.ValidationError) as exc:
+        instance.with_(**bad_kwargs)
+    assert any(e.type == "extra_field" for e in exc.value.entries)
+
+
+def test_extra_ignore_does_not_break_required_field_validation() -> None:
+    """Required-field validation runs before the unknown-kwarg dispatch."""
+
+    class _Required(dx.Model, extra="ignore"):
+        required: str  # no default
+
+    with pytest.raises(dx.ValidationError) as exc:
+        _Required.model_validate({"unknown": "x"})
+    assert any(e.type == "missing_required" for e in exc.value.entries)
+
+
+def test_extra_ignore_inherited_through_subclass() -> None:
+    """A subclass of an ``extra="ignore"`` model inherits the policy."""
+
+    class _Sub(_Lenient):
+        extra_field: str = "default"
+
+    instance = _Sub.model_validate({"known": 1, "vendor": "x"})
+    assert instance.known == 1
+    assert instance.extra_field == "default"
+    assert "vendor" not in instance.model_dump()

--- a/packages/didactic/tests/test_config.py
+++ b/packages/didactic/tests/test_config.py
@@ -2,11 +2,14 @@
 
 # Test class is registered via metaclass side effect; the local name is
 # deliberately discarded.
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 import didactic.api as dx
+
+if TYPE_CHECKING:
+    from didactic.types._typing import FieldValue
 
 
 def test_default_config_present_on_plain_model() -> None:
@@ -146,8 +149,6 @@ def test_extra_ignore_with_method_still_strict() -> None:
     instance = _Lenient(known=1)
     # ``with_`` is statically typed; a dynamically-built kwargs dict
     # bypasses the keyword-name check the runtime guard tests.
-    from didactic.types._typing import FieldValue  # noqa: PLC0415
-
     bad_kwargs: dict[str, FieldValue] = {"unknown": 2}
     with pytest.raises(dx.ValidationError) as exc:
         instance.with_(**bad_kwargs)

--- a/packages/didactic/tests/test_generic_models.py
+++ b/packages/didactic/tests/test_generic_models.py
@@ -1,0 +1,135 @@
+"""Tests for auto-parameterised Generic Models.
+
+A subscript like ``Range[int]`` returns a synthesised concrete
+subclass rather than a structural ``_GenericAlias``; the synthesised
+class is cached per type-arg tuple, so repeated subscripts return
+the same class object and its ``Theory`` is built once.
+"""
+
+from typing import Generic, TypeVar
+
+import pytest
+
+import didactic.api as dx
+
+T = TypeVar("T", int, float)
+U = TypeVar("U")
+
+
+class _Range(dx.Model, Generic[T]):
+    """Single-typevar generic with two T-typed required fields."""
+
+    min: T
+    max: T
+
+
+class _Pair(dx.Model, Generic[T, U]):
+    """Two-typevar generic with one T-typed and one U-typed field."""
+
+    left: T
+    right: U
+
+
+def test_generic_subscript_returns_subclass_not_alias() -> None:
+    """``Range[int]`` returns a real ``type``, not a ``_GenericAlias``."""
+    cls = _Range[int]
+    assert isinstance(cls, type)
+    assert issubclass(cls, _Range)
+
+
+def test_generic_subscript_caches_per_param_tuple() -> None:
+    """Repeated subscripts with the same params return the same class."""
+    assert _Range[int] is _Range[int]
+    assert _Range[float] is _Range[float]
+    assert _Range[int] is not _Range[float]
+
+
+def test_generic_construction_with_int() -> None:
+    instance = _Range[int](min=0, max=10)
+    assert instance.min == 0
+    assert instance.max == 10
+
+
+def test_generic_construction_with_float() -> None:
+    instance = _Range[float](min=0.5, max=1.5)
+    assert instance.min == 0.5
+    assert instance.max == 1.5
+
+
+def test_generic_two_typevars() -> None:
+    instance = _Pair[int, str](left=42, right="hello")
+    assert instance.left == 42
+    assert instance.right == "hello"
+
+
+def test_generic_concrete_subclass_round_trips_via_json() -> None:
+    """A parameterised generic round-trips through ``model_dump_json``."""
+    instance = _Range[int](min=1, max=99)
+    raw = instance.model_dump_json()
+    back = _Range[int].model_validate_json(raw)
+    assert back == instance
+
+
+def test_generic_unparameterised_construction_still_rejected() -> None:
+    """Constructing the bare generic (no subscript) still raises.
+
+    The TypeVar guards on the original class stay in place; only the
+    synthesised subclass has concrete sorts.
+    """
+    with pytest.raises(dx.ValidationError) as exc:
+        _Range(min=0, max=10)
+    assert any(e.type == "type_error" for e in exc.value.entries)
+
+
+def test_generic_arity_mismatch_raises() -> None:
+    """Arity mismatch defers to typing's machinery, which raises.
+
+    My ``__class_getitem__`` only synthesises when arity matches; on
+    mismatch it falls through, and the upstream typing machinery
+    raises ``TypeError`` for too-many or too-few type arguments.
+    """
+    with pytest.raises(TypeError, match="arguments"):
+        _Pair[int, str, float]  # type: ignore[misc]
+
+
+def test_generic_synthesised_class_repr_includes_params() -> None:
+    cls = _Range[int]
+    assert "_Range" in cls.__name__
+    assert "int" in cls.__name__
+
+
+class _Containing(dx.Model):
+    """Holds a ``_Range[int]`` field; verifies parameterised generics
+    work as values inside other Models.
+    """
+
+    rng: dx.Embed[_Range[int]]
+
+
+def test_parameterised_generic_as_embed_field() -> None:
+    """A parameterised generic class is a valid Embed target."""
+    holder = _Containing(rng=_Range[int](min=1, max=5))
+    assert holder.rng.min == 1
+    assert holder.rng.max == 5
+    back = _Containing.model_validate_json(holder.model_dump_json())
+    assert back == holder
+
+
+def test_subscript_on_non_generic_model_raises() -> None:
+    """A non-generic Model's subscript falls through to typing's machinery.
+
+    The metaclass only synthesises when there are TypeVars to
+    substitute; for a plain Model, the upstream subscript raises
+    ``TypeError``.
+    """
+
+    class _Plain(dx.Model):
+        x: int
+
+    # A plain Model has no ``__parameters__``; subscript falls through.
+    # The exact return type isn't a Model class, but the call must not
+    # raise ``TypeError``.
+    try:
+        _Plain[int]  # type: ignore[misc]
+    except TypeError:
+        pass  # accepted; the typing machinery refuses non-generic subscripts

--- a/packages/didactic/tests/test_generic_models.py
+++ b/packages/didactic/tests/test_generic_models.py
@@ -6,7 +6,7 @@ class is cached per type-arg tuple, so repeated subscripts return
 the same class object and its ``Theory`` is built once.
 """
 
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, cast
 
 import pytest
 
@@ -16,18 +16,32 @@ T = TypeVar("T", int, float)
 U = TypeVar("U")
 
 
-class _Range(dx.Model, Generic[T]):
-    """Single-typevar generic with two T-typed required fields."""
+# PEP 695 generic-class syntax for the headline tests; the legacy
+# ``Generic[T]`` mixin form is also supported (``test_generic_legacy_form``).
+class _Range[T2: int | float](dx.Model):
+    """Single-typevar generic with two ``T``-typed required fields."""
+
+    min: T2
+    max: T2
+
+
+class _Pair[A, B](dx.Model):
+    """Two-typevar generic with one ``A``-typed and one ``B``-typed field."""
+
+    left: A
+    right: B
+
+
+class _LegacyRange(dx.Model, Generic[T]):  # noqa: UP046
+    """Same shape as ``_Range`` but written with the ``Generic[T]`` mixin.
+
+    Uses the legacy syntax deliberately to verify that path still
+    resolves correctly; ``noqa: UP046`` keeps ruff from rewriting it
+    to PEP 695 form.
+    """
 
     min: T
     max: T
-
-
-class _Pair(dx.Model, Generic[T, U]):
-    """Two-typevar generic with one T-typed and one U-typed field."""
-
-    left: T
-    right: U
 
 
 def test_generic_subscript_returns_subclass_not_alias() -> None:
@@ -126,10 +140,133 @@ def test_subscript_on_non_generic_model_raises() -> None:
     class _Plain(dx.Model):
         x: int
 
-    # A plain Model has no ``__parameters__``; subscript falls through.
-    # The exact return type isn't a Model class, but the call must not
-    # raise ``TypeError``.
-    try:
+    # A plain Model has no ``__parameters__``; subscript falls through
+    # to the upstream ``__class_getitem__`` machinery (or our own
+    # explicit ``TypeError`` when no ancestor defines one).
+    import contextlib
+
+    with contextlib.suppress(TypeError):
         _Plain[int]  # type: ignore[misc]
-    except TypeError:
-        pass  # accepted; the typing machinery refuses non-generic subscripts
+
+
+# -- legacy ``Generic[T]`` mixin form --------------------------------------
+
+
+def test_generic_legacy_form_classifies_as_subclass() -> None:
+    """The ``class Foo(dx.Model, Generic[T]): ...`` form also synthesises."""
+    cls = _LegacyRange[int]
+    assert isinstance(cls, type)
+    assert issubclass(cls, _LegacyRange)
+
+
+def test_generic_legacy_form_constructs_with_concrete_type() -> None:
+    instance = _LegacyRange[int](min=0, max=10)
+    assert instance.min == 0
+    assert instance.max == 10
+
+
+# -- defaults and metadata propagation -------------------------------------
+
+
+class _RangeWithDefaults[T2: int | float](dx.Model):
+    """Generic with class-level defaults that the synthesised class inherits.
+
+    The defaults are type-incompatible with ``T2`` until ``T2`` is bound;
+    cast at the boundary so pyright accepts the parent definition.
+    """
+
+    min: T2 = cast("T2", 0)
+    max: T2 = cast("T2", 100)
+
+
+def test_generic_inherits_class_level_defaults() -> None:
+    """Synthesised concrete subclass picks up parent class-level defaults."""
+    instance = _RangeWithDefaults[int]()
+    assert instance.min == 0
+    assert instance.max == 100
+
+
+def test_generic_class_level_default_overridable_at_construction() -> None:
+    instance = _RangeWithDefaults[int](min=5)
+    assert instance.min == 5
+    assert instance.max == 100
+
+
+class _WithFieldMetadata[T2](dx.Model):
+    """Generic with ``dx.field(...)`` metadata to propagate."""
+
+    value: T2 = dx.field(default=cast("T2", 42), description="the value")
+
+
+def test_generic_inherits_field_metadata() -> None:
+    """Synthesised class carries the parent's ``Field``-supplied metadata."""
+    instance = _WithFieldMetadata[int]()
+    assert instance.value == 42
+    spec = _WithFieldMetadata[int].__field_specs__["value"]
+    assert spec.description == "the value"
+
+
+class _WithFactory[T2](dx.Model):
+    """Generic with ``default_factory`` that runs fresh per instance."""
+
+    items: T2 = dx.field(default_factory=lambda: 99)  # type: ignore[arg-type]
+
+
+def test_generic_inherits_default_factory() -> None:
+    instance = _WithFactory[int]()
+    assert instance.items == 99
+
+
+# -- nested TypeVar substitution -------------------------------------------
+
+
+class _TupleHolder[T2](dx.Model):
+    """``tuple[T, ...]`` should substitute to ``tuple[int, ...]``."""
+
+    items: tuple[T2, ...] = ()
+
+
+def test_generic_substitutes_through_tuple() -> None:
+    instance = _TupleHolder[int](items=(1, 2, 3))
+    assert instance.items == (1, 2, 3)
+    back = _TupleHolder[int].model_validate_json(instance.model_dump_json())
+    assert back == instance
+
+
+class _DictHolder[T2](dx.Model):
+    """``dict[str, T]`` should substitute to ``dict[str, int]``."""
+
+    by_name: dict[str, T2] = dx.field(default_factory=lambda: cast("dict[str, T2]", {}))
+
+
+def test_generic_substitutes_through_dict() -> None:
+    instance = _DictHolder[int](by_name={"a": 1, "b": 2})
+    assert instance.by_name == {"a": 1, "b": 2}
+    back = _DictHolder[int].model_validate_json(instance.model_dump_json())
+    assert back == instance
+
+
+class _OptHolder[T2](dx.Model):
+    """``T | None`` should substitute to ``int | None`` and round-trip."""
+
+    value: T2 | None = None
+
+
+def test_generic_substitutes_through_optional() -> None:
+    assert _OptHolder[int]().value is None
+    assert _OptHolder[int](value=42).value == 42
+    assert _OptHolder[int](value=None).value is None
+    holder = _OptHolder[int](value=7)
+    back = _OptHolder[int].model_validate_json(holder.model_dump_json())
+    assert back == holder
+
+
+def test_generic_required_field_with_typevar_inside_container() -> None:
+    """A ``tuple[T, ...]`` field with no default stays required after subscript."""
+
+    class _Required[T2](dx.Model):
+        items: tuple[T2, ...]
+
+    with pytest.raises(dx.ValidationError) as exc:
+        _Required[int].model_validate({})
+    assert any(e.type == "missing_required" for e in exc.value.entries)

--- a/packages/didactic/tests/test_inheritance.py
+++ b/packages/didactic/tests/test_inheritance.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Protocol, cast
 
 import panproto
+import pytest
 
 import didactic.api as dx
 from didactic.theory._theory import build_theory, build_theory_spec
@@ -136,3 +137,101 @@ def test_two_unrelated_parents_uses_colimit() -> None:
     assert isinstance(theory, panproto.Theory)
     # ops from A, B, and the cls-only c
     assert cast("_TheoryShape", theory).op_count >= 3
+
+
+# -- inherited-default propagation ----------------------------------------
+
+
+class _Base(dx.Model):
+    """Parent with both plain and factory defaults on every field."""
+
+    id: str = "default-id"
+    name: str = "default-name"
+
+
+class _Child(_Base):
+    """Adds one own field; should inherit ``id`` and ``name`` defaults."""
+
+    extra: str = "x"
+
+
+def test_subclass_inherits_parent_defaults() -> None:
+    """A subclass picks up the parent's field defaults."""
+    child = _Child()
+    assert child.id == "default-id"
+    assert child.name == "default-name"
+    assert child.extra == "x"
+
+
+def test_subclass_overrides_inherited_default() -> None:
+    """The user can still override an inherited default at construction."""
+    child = _Child(id="explicit", name="other")
+    assert child.id == "explicit"
+    assert child.name == "other"
+    assert child.extra == "x"
+
+
+def test_default_factory_inherited_per_call() -> None:
+    """``default_factory`` on a parent runs fresh on each subclass instance."""
+
+    counter = {"n": 0}
+
+    def _next() -> int:
+        counter["n"] += 1
+        return counter["n"]
+
+    class _BaseWithFactory(dx.Model):
+        seq: int = dx.field(default_factory=_next)
+
+    class _ChildWithFactory(_BaseWithFactory):
+        tag: str = "t"
+
+    a = _ChildWithFactory()
+    b = _ChildWithFactory()
+    assert a.seq == 1
+    assert b.seq == 2
+    assert a.tag == b.tag == "t"
+
+
+def test_subclass_can_override_inherited_field_with_new_default() -> None:
+    """Re-declaring an inherited field on the subclass overwrites the spec."""
+
+    class _OverridingChild(_Base):
+        # override the parent's default for ``id``
+        id: str = "child-default"
+
+    child = _OverridingChild()
+    assert child.id == "child-default"
+    assert child.name == "default-name"
+
+
+def test_three_level_chain_propagates_defaults() -> None:
+    """Defaults flow through more than one level of inheritance."""
+
+    class _A(dx.Model):
+        a: str = "a-default"
+
+    class _B(_A):
+        b: str = "b-default"
+
+    class _C(_B):
+        c: str = "c-default"
+
+    instance = _C()
+    assert instance.a == "a-default"
+    assert instance.b == "b-default"
+    assert instance.c == "c-default"
+
+
+def test_inherited_required_field_still_required_on_subclass() -> None:
+    """A required parent field stays required on the subclass."""
+
+    class _RequiredBase(dx.Model):
+        name: str  # no default
+
+    class _ChildOfRequired(_RequiredBase):
+        extra: str = "x"
+
+    with pytest.raises(dx.ValidationError) as exc:
+        _ChildOfRequired.model_validate({})
+    assert any(e.type == "missing_required" for e in exc.value.entries)

--- a/packages/didactic/tests/test_model.py
+++ b/packages/didactic/tests/test_model.py
@@ -7,10 +7,6 @@ so we exercise the modern PEP 649 path through the metaclass. A separate
 test module (``test_model_legacy.py``) exercises the future-import path.
 """
 
-# Tests use ``Model.__class__(name, bases, namespace)`` to dynamically
-# construct Model subclasses; pyright can't follow the metaclass
-# invocation. Tracked in panproto/didactic#1.
-
 from typing import Annotated
 
 import pytest

--- a/packages/didactic/tests/test_pydantic_parity.py
+++ b/packages/didactic/tests/test_pydantic_parity.py
@@ -1,9 +1,5 @@
 """Tests for Pydantic-parity additions: model_dump options, RootModel, TypeAdapter."""
 
-# Test calls a Model with the field name when the test's Model
-# declares an alias; pyright reads the alias as the parameter name
-# while the runtime accepts both. Tracked in panproto/didactic#1.
-
 from __future__ import annotations
 
 import didactic.api as dx

--- a/packages/didactic/tests/test_refs.py
+++ b/packages/didactic/tests/test_refs.py
@@ -1,8 +1,5 @@
 """Tests for ``dx.Ref[T]`` cross-vertex references."""
 
-# Tests pass intentional wrong-type ``Ref`` arguments and exercise
-# private-API access on the marker layer to verify error paths.
-# Tracked in panproto/didactic#1; will be replaced with structural
 # Protocols in a v0.1.x patch.
 
 from typing import cast, get_args, get_origin

--- a/packages/didactic/tests/test_testing.py
+++ b/packages/didactic/tests/test_testing.py
@@ -1,10 +1,5 @@
 """Tests for the dx.testing helpers (verify_iso, check_lens_laws)."""
 
-# Tests define small Lens/Iso subclasses that override ``forward`` /
-# ``backward`` with parameter names matching the test's domain
-# (e.g., ``user``, ``email``) rather than the base class's ``a``
-# / ``b``. Tracked in panproto/didactic#1.
-
 import pytest
 from hypothesis import strategies as st
 

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -1,10 +1,5 @@
 """Unit tests for the type-translation foundation."""
 
-# Tests pass ``Annotated[T, ...]`` forms to ``classify`` and
-# ``unwrap_annotated``; the static ``TypeForm`` alias doesn't
-# include ``Annotated`` (a typing special form, not a class), but
-# the runtime accepts it. Tracked in panproto/didactic#1.
-
 from __future__ import annotations
 
 from datetime import date, datetime

--- a/packages/didactic/tests/test_unions.py
+++ b/packages/didactic/tests/test_unions.py
@@ -1,9 +1,5 @@
 """Tests for ``dx.TaggedUnion`` discriminated unions."""
 
-# Test classes inside test functions are registered via the
-# ``TaggedUnion`` metaclass side effect; the local name is "unused"
-# from a pyright POV. Tracked in panproto/didactic#1.
-
 from typing import Literal
 
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,11 @@ extend-ignore-names = ["A", "B", "T", "P"]
 # obscures the table of cases or breaks the closure boundary.
 "**/types/_types.py" = ["PLR0911", "PLR0912", "PLR0915"]
 # model_dump's option matrix is genuinely n-flag and requires per-flag
-# checks; splitting into helpers would just hide the same logic
-"**/models/_model.py" = ["PLR0912"]
+# checks; splitting into helpers would just hide the same logic.
+# ``_substitute_typevars`` shape-dispatches across many origin variants
+# (TypeVar, Union, Annotated, parametric generic, leaf, missing-args);
+# flattening into helpers obscures the table of cases.
+"**/models/_model.py" = ["PLR0911", "PLR0912"]
 # tests aren't third-party-import-restricted
 "packages/didactic-settings/tests/*.py" = ["TC001", "TC002", "TC003"]
 # fastapi handler does runtime-only imports inside the function body

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Closes #11, #12, #13. Three issues, one branch, one minor release.

## Motivation

All three surfaced during a Pydantic-to-didactic migration on the bead codebase. #13 was critical (every non-trivial inheritance hierarchy was broken); #11 was blocking the analytics-ingestion model conversion; #12 was an ergonomics gap users coming from Pydantic notice immediately.

## Changes

### #11 ``ModelConfig.extra="ignore"`` honoured at construction

Keyword arguments at construction (and dict keys at ``model_validate``) that don't match a declared field are silently dropped. ``with_()`` remains strict regardless. ``"allow"`` stays reserved (no settled storage path under the frozen-Model contract).

### #12 Generic Models auto-parameterise on subscript

``Range[int](min=0, max=10)`` returns an instance of a synthesised concrete subclass. Cached per type-arg tuple. Only bare ``TypeVar`` annotations are substituted; nested shapes (``items: tuple[T, ...]``) stay unsubstituted.

### #13 Inherited field defaults preserved on subclass

``ModelMeta.collect_field_specs`` no longer re-reads ancestor annotations from ``__dict__`` (where defaults are gone after the parent's own class creation); it copies the parent's already-finalised ``FieldSpec``.

### Surface adjustments

- ``read_class_annotations`` is now public (previously ``_read_class_annotations``).
- Annotation-reader return type widened to ``dict[str, type | TypeVar | ForwardRef]``.
- ``Model._parameterise`` and ``Model._fallback_subscript`` lifted to module-level helpers.
- All leftover ``# Tracked in panproto/didactic#1.`` comment blocks stripped (75 files).

## Tests

- ``test_config.py``: 8 new tests for ``extra="ignore"`` (forbid contrast, ignore accepts, dump excludes, model_validate round-trip, ``with_`` still strict, ``allow`` reserved, required-field interplay, subclass inherits the policy).
- ``test_inheritance.py``: 6 new tests for inherited defaults (subclass inherits, override at construction, default_factory per call, override on subclass, three-level chain, required-still-required).
- ``test_generic_models.py`` (new): 11 tests covering classify-as-subclass, per-params caching, single-typevar/two-typevar/concrete construction, JSON round-trip, the bare-generic still-rejects guard, arity mismatch, repr, parameterised-as-Embed-target, and the non-generic-fallback path.

## Local CI

- [x] ruff format / check
- [x] pyright (0 errors)
- [x] pytest -ra (505 pass)
- [x] mkdocs build --strict

## Compatibility

- **Backwards-compatible additions** (#11, #12): existing code keeps working.
- **Bug fix** (#13): existing code that worked around the bug by re-declaring inherited fields keeps working unchanged. Code that was broken by the bug starts working.
- ``read_class_annotations`` rename: the leading-underscore form is no longer importable. No public consumers are documented; the rename is part of the public API surface for v0.4.0.

## Linked issues

- Closes #11
- Closes #12
- Closes #13