### PR TITLE
fix(types): coerce list to tuple/frozenset at encoder boundary (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-05
+
+### Fixed
+
+- ``tuple[T, ...]``-typed fields now coerce list input to tuple at the
+  encoder boundary instead of raising a bare ``AssertionError``.
+  Mirrors Pydantic's affordance so call sites migrating across don't
+  have to rewrite every ``indices=[0, 1, 2]`` literal. Non-iterable
+  input still fails, but as a ``dx.ValidationError`` carrying the
+  field name and a ``type_error`` entry, not as an ``AssertionError``
+  from inside the encoder. ([#15])
+- ``frozenset[T]``-typed fields coerce list, set, and tuple input the
+  same way. Bare strings are still rejected (they would otherwise
+  silently explode into ``frozenset({"a", "b", "c"})``).
+
+[#15]: https://github.com/panproto/didactic/issues/15
+
 ## [0.4.0] - 2026-05-05
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.4.0"
+version = "0.4.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.4.0"
+version = "0.4.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.4.0"
+version = "0.4.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.4.0"
+version = "0.4.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -1357,8 +1357,18 @@ def _make_list_encoder(
 ) -> Callable[[FieldValue], Encoded]:
     def enc(v: FieldValue) -> Encoded:
         # JSON-encode the encoded items; the panproto string is therefore
-        # always a valid JSON array literal.
-        assert isinstance(v, tuple)
+        # always a valid JSON array literal. Accept list as well as tuple
+        # so call sites migrating from Pydantic (which transparently
+        # coerces list to tuple for tuple-typed fields) do not have to
+        # rewrite every ``indices=[0, 1, 2]`` literal. Reject anything
+        # else with ``TypeError`` so the caller's ``ValidationError``
+        # carries the field name instead of a bare ``AssertionError``.
+        if not isinstance(v, (tuple, list)):
+            msg = (
+                f"expected tuple or list for tuple[T, ...] field, "
+                f"got {type(v).__name__}"
+            )
+            raise TypeError(msg)
         return json.dumps([inner_encode(item) for item in v])
 
     return enc
@@ -1384,7 +1394,20 @@ def _classify_frozenset(args: tuple[TypeForm, ...]) -> TypeTranslation:
     inner = classify(args[0])
 
     def enc(v: FieldValue) -> Encoded:
-        assert isinstance(v, frozenset)
+        # Accept any non-string iterable that can lawfully be coerced to
+        # ``frozenset`` (set, frozenset, list, tuple). The same reasoning
+        # as the tuple encoder applies: Pydantic coerces, callers
+        # migrating across should not have to rewrite every literal, and
+        # rejecting via ``TypeError`` keeps the failure inside
+        # ``ValidationError``.
+        if isinstance(v, (str, bytes, bytearray)) or not isinstance(
+            v, (frozenset, set, list, tuple)
+        ):
+            msg = (
+                f"expected frozenset, set, list, or tuple for frozenset[T] "
+                f"field, got {type(v).__name__}"
+            )
+            raise TypeError(msg)
         return json.dumps(sorted(inner.encode(item) for item in v))
 
     def dec(s: Encoded) -> frozenset[FieldValue]:

--- a/packages/didactic/tests/test_model.py
+++ b/packages/didactic/tests/test_model.py
@@ -219,3 +219,63 @@ def test_derived_construct() -> None:
     d = _Derived(id="x")
     assert d.id == "x"
     assert d.name == ""
+
+
+# -- container coercion ----------------------------------------------------
+
+
+class _Span(dx.Model):
+    indices: tuple[int, ...]
+
+
+class _Bag(dx.Model):
+    tags: frozenset[str]
+
+
+# These tests deliberately pass list literals where the field annotation
+# requires tuple/frozenset, to exercise the runtime coercion on the
+# encoder boundary. The type checker is correct to flag the call sites;
+# the carve-outs below are scoped to the assertion under test.
+
+
+def test_tuple_field_accepts_list_input() -> None:
+    """``tuple[T, ...]`` field coerces list input to tuple.
+
+    Mirrors Pydantic's affordance so call sites migrating across
+    don't have to rewrite every ``indices=[0, 1, 2]`` literal.
+    """
+    s = _Span(indices=[0, 1, 2])  # type: ignore[arg-type]
+    assert s.indices == (0, 1, 2)
+    assert isinstance(s.indices, tuple)
+
+
+def test_tuple_field_with_accepts_list_input() -> None:
+    """The same coercion applies on ``.with_(...)``."""
+    s = _Span(indices=(0,)).with_(indices=[1, 2, 3])  # type: ignore[arg-type]
+    assert s.indices == (1, 2, 3)
+
+
+def test_tuple_field_scalar_raises_validation_error_with_field_name() -> None:
+    """A non-iterable input surfaces as ``ValidationError``, not bare assert."""
+    with pytest.raises(dx.ValidationError) as exc:
+        _Span(indices=42)  # type: ignore[arg-type]
+    entries = exc.value.entries
+    assert len(entries) == 1
+    assert entries[0].loc == ("indices",)
+    assert entries[0].type == "type_error"
+    assert "tuple" in entries[0].msg
+
+
+def test_frozenset_field_accepts_list_input() -> None:
+    """``frozenset[T]`` field coerces list input to frozenset."""
+    b = _Bag(tags=["a", "b", "a"])  # type: ignore[arg-type]
+    assert b.tags == frozenset({"a", "b"})
+
+
+def test_frozenset_field_string_raises_validation_error() -> None:
+    """A bare string is rejected even though it is iterable."""
+    with pytest.raises(dx.ValidationError) as exc:
+        _Bag(tags="abc")  # type: ignore[arg-type]
+    entries = exc.value.entries
+    assert entries[0].loc == ("tags",)
+    assert entries[0].type == "type_error"

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -112,6 +112,47 @@ def test_tuple_of_strings() -> None:
     assert t.decode(t.encode(("a", "b"))) == ("a", "b")
 
 
+def test_tuple_encoder_accepts_list() -> None:
+    """``tuple[T, ...]`` encoder coerces list input to tuple.
+
+    Mirrors Pydantic's affordance so call sites migrating across do
+    not have to rewrite every ``[0, 1, 2]`` literal to a tuple.
+    """
+    t = classify(tuple[int, ...])
+    assert t.decode(t.encode(cast("FieldValue", [1, 2, 3]))) == (1, 2, 3)
+
+
+def test_tuple_encoder_rejects_scalar_with_typeerror() -> None:
+    """Non-iterable input raises ``TypeError`` (not ``AssertionError``).
+
+    Bubbling out as ``TypeError`` lets the model's ``__init__`` route
+    the failure into ``ValidationError`` with a field-named entry.
+    """
+    t = classify(tuple[int, ...])
+    with pytest.raises(TypeError, match="expected tuple or list"):
+        t.encode(cast("FieldValue", 42))
+
+
+def test_frozenset_encoder_accepts_list_and_set() -> None:
+    """``frozenset[T]`` encoder coerces list, set, and tuple input."""
+    t = classify(frozenset[int])
+    assert t.decode(t.encode(cast("FieldValue", [3, 1, 2]))) == frozenset([1, 2, 3])
+    assert t.decode(t.encode(cast("FieldValue", {3, 1, 2}))) == frozenset([1, 2, 3])
+    assert t.decode(t.encode(cast("FieldValue", (3, 1, 2)))) == frozenset([1, 2, 3])
+
+
+def test_frozenset_encoder_rejects_string_with_typeerror() -> None:
+    """Strings are iterable but the encoder must not accept them.
+
+    Without the explicit guard ``"abc"`` would be silently exploded
+    into ``frozenset({"a", "b", "c"})``, which is almost never what
+    the caller meant.
+    """
+    t = classify(frozenset[int])
+    with pytest.raises(TypeError, match="expected frozenset"):
+        t.encode(cast("FieldValue", "abc"))
+
+
 def test_frozenset() -> None:
     t = classify(frozenset[int])
     assert t.sort == "Set Int"

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

`tuple[T, ...]`-typed fields raised a bare `AssertionError` (no
message, no field name) when handed a list at construction. This PR
makes the encoder coerce list to tuple, mirroring Pydantic's
affordance, and routes any genuine type mismatch through
`dx.ValidationError` with the field name attached. Same treatment for
`frozenset[T]`. Closes #15.

## Motivation

Surfaced while migrating `bead` from Pydantic. Pydantic transparently
accepts list input on tuple-typed fields, so call sites and test
fixtures across the migrating codebase pass `indices=[0, 1, 2]`,
`segments=[...]`, `spans=[...]` literals. didactic 0.4.0 raised a bare
`AssertionError` from `_types.py:1361` for each one, which
(1) carried no field name, (2) bypassed `dx.ValidationError`, and
(3) read like an internal invariant violation rather than user error.

The reporter's preference (option 1 in the issue) was coercion over
strict rejection, because the immutability invariant is preserved
either way (the stored value is still a tuple) and migrations get
dramatically lighter.

## Changes

- `packages/didactic/src/didactic/types/_types.py` —
  `_make_list_encoder` (used by `tuple[T, ...]`) accepts list as well
  as tuple. `_classify_frozenset`'s encoder accepts frozenset, set,
  list, and tuple. Both raise `TypeError` (not `AssertionError`) on
  rejected input so the failure routes through `ValidationError` with
  the field name. Bare strings are explicitly rejected from the
  frozenset path.
- `packages/didactic/tests/test_types.py` — encoder-level coverage:
  list coercion on tuple, scalar rejection, frozenset accepting
  list/set/tuple, frozenset rejecting string.
- `packages/didactic/tests/test_model.py` — end-to-end coverage: the
  issue's exact `Span(indices=[0, 1, 2])` repro, `.with_(indices=[...])`,
  the `ValidationError` shape on scalar input, and the frozenset
  variants.
- `CHANGELOG.md` — `[0.4.1] - 2026-05-05` entry.
- All four package versions bumped to 0.4.1.

## Tests

524 tests pass (10 new, all in the changed area). The new tests
cover both the encoder-level translation in isolation and the
end-to-end Model path so a regression at either layer is caught.

The `# type: ignore[arg-type]` directives on the new model tests are
deliberate: they pass list literals where the field annotation
requires tuple/frozenset, to exercise the runtime coercion. The
static check is correct to flag the call sites; the test asserts the
runtime accepts them.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (524 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Behaviour change** — existing public API behaves differently.
  `tuple[T, ...]` and `frozenset[T]` fields previously rejected list
  input with a bare `AssertionError`; they now accept it and coerce.
  No call site that previously worked breaks; only previously-broken
  call sites become valid. The migration path is "do nothing" — code
  that already passed tuples keeps working unchanged.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.4.1]`.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.
- [ ] Suppressions added/changed are listed below with a link to the
  tracking issue and a one-line rationale.

(The `# type: ignore[arg-type]` directives on the new model tests are
not pyright suppressions; they're per-line type-checker carve-outs
scoped to assertions that deliberately exercise runtime coercion of
list literals into tuple/frozenset fields.)

## Linked issues

Closes #15.