### PR TITLE
fix(models): wire @dx.validates so tagged methods actually run (v0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-05
+
+### Fixed
+
+- ``@dx.validates`` is no longer a silent no-op. The metaclass now
+  walks ``target.__mro__`` for methods carrying the
+  ``__didactic_validator__`` marker and stores them on the class as
+  ``__field_validators__``; ``Model.__init__`` and ``Model.with_(...)``
+  invoke them in the right order: ``dx.field(converter=...)`` first,
+  then ``mode="before"`` validators on the raw value, then the
+  encoder, then ``mode="after"`` validators on the canonical decoded
+  value (re-encoded if the validator returned a different value).
+  Validators may ``raise ValueError`` / ``raise TypeError`` to reject
+  the input; failures surface as ``ValidationError`` entries with
+  ``type="validator_error"`` and ``loc=(field_name,)``. Instance,
+  ``@classmethod``, and ``@staticmethod`` shapes all work. Subclasses
+  inherit a parent's validators; a subclass override that re-applies
+  ``@validates`` replaces the inherited method, and a subclass that
+  shadows the method without ``@validates`` deliberately disables
+  validation for that field. ([#17])
+
+### Changed
+
+- ``docs/guide/validators.md`` was rewritten to document the
+  ``raise ValueError`` / return-value-replaces-stored-value contract
+  (the previous draft described a ``return bool`` shape that the
+  runtime never implemented), and to cover ``mode="before"``,
+  multi-field validators, multiple-validator chaining, inheritance
+  semantics, and the three method shapes.
+
+[#17]: https://github.com/panproto/didactic/issues/17
+
 ## [0.4.1] - 2026-05-05
 
 ### Fixed

--- a/docs/guide/validators.md
+++ b/docs/guide/validators.md
@@ -1,7 +1,8 @@
 # Validators
 
-[didactic.api.validates][didactic.api.validates] decorates a method as a
-per-field check that runs at construction time:
+[didactic.api.validates][didactic.api.validates] decorates a method as
+a per-field check that runs at construction time and on
+[`with_(...)`][didactic.api.Model.with_]:
 
 ```python
 import didactic.api as dx
@@ -12,18 +13,123 @@ class User(dx.Model):
     email: str
 
     @dx.validates("email")
-    def _email_must_have_at(self, value: str) -> bool:
-        return "@" in value
+    def _check_email(self, value: str) -> str:
+        if "@" not in value:
+            raise ValueError("missing '@'")
+        return value.lower()
 ```
 
-The validator runs after the field's type translation. Its argument
-is the decoded value; its return value must be `bool`. `False`
-raises a `ValidationError` with a `validates_failed` entry.
+A validator receives the field value and **returns the value to
+store** (possibly modified). To reject the input, `raise ValueError`
+or `raise TypeError`; the failure is collected as a
+`ValidationError` entry with `type="validator_error"` and
+`loc=(field_name,)`.
+
+## ``before`` and ``after``
+
+`@validates` accepts a `mode` argument:
+
+- ``mode="after"`` (the default) runs after the encoder has
+  type-validated the input. The validator sees the canonical
+  decoded form: a `tuple` for `tuple[T, ...]` fields, a `frozenset`
+  for `frozenset[T]` fields, and so on. Its return value is
+  re-encoded if it differs from the input.
+- ``mode="before"`` runs *before* the encoder, on the raw user input
+  (after any `dx.field(converter=...)` has already run). Use this
+  for normalisation that should happen before the type check, e.g.
+  lowercasing a string to compare against a `Literal`.
+
+```python
+class Email(dx.Model):
+    address: str
+
+    @dx.validates("address", mode="before")
+    def _lower(self, value: str) -> str:
+        return value.lower()
+```
+
+## Method shapes
+
+The decorator works on instance methods, `@classmethod`, and
+`@staticmethod`. The Model is frozen and not yet constructed when
+validators run, so there is no instance ``self``. Instance methods
+receive the **class** as their first argument:
+
+```python
+class M(dx.Model):
+    name: str
+
+    @dx.validates("name")
+    def _strip(cls, value: str) -> str:   # name `cls` is conventional
+        return value.strip()
+
+    @dx.validates("name")
+    @classmethod
+    def _check_nonempty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("empty")
+        return value
+
+    @dx.validates("name")
+    @staticmethod
+    def _trim(value: str) -> str:
+        return value.strip()
+```
+
+## Multiple fields share a validator
+
+```python
+class Pair(dx.Model):
+    first: str
+    last: str
+
+    @dx.validates("first", "last")
+    def _strip(cls, value: str) -> str:
+        return value.strip()
+```
 
 ## Multiple validators per field
 
 Multiple `@validates` methods on the same field run in declaration
-order. The first failure short-circuits the rest for that field.
+order, threading the value through. The first one to raise
+short-circuits the chain for that field.
+
+```python
+class Word(dx.Model):
+    text: str
+
+    @dx.validates("text")
+    def _strip(cls, v: str) -> str:
+        return v.strip()
+
+    @dx.validates("text")
+    def _upper(cls, v: str) -> str:
+        return v.upper()
+```
+
+## Inheritance
+
+Subclasses inherit their parent's validators. To **override** an
+inherited validator, redeclare the method *with* `@validates`:
+
+```python
+class Base(dx.Model):
+    name: str
+
+    @dx.validates("name")
+    def _strip(cls, v: str) -> str:
+        return v.strip()
+
+
+class Loud(Base):
+    @dx.validates("name")
+    def _strip(cls, v: str) -> str:
+        return v.strip().upper()
+```
+
+A subclass that shadows the method *without* `@validates` is treated
+as a deliberate disable: the inherited marker is dropped and the
+field skips validation.
 
 ## Cross-field invariants
 
@@ -38,6 +144,14 @@ class Range(dx.Model):
     __axioms__ = [dx.axiom("low <= high")]
 ```
 
+## Validators do not travel with the Theory
+
+`@validates`-decorated methods live on the Python side only; they are
+**not** lifted into the panproto Theory. Constraints expressed as
+`Annotated[T, ...]` metadata or as `__axioms__` *are* lifted.
+Choose the axiom path when you want the constraint to travel
+cross-language with the Theory.
+
 ## Validation error shape
 
 ```python
@@ -51,11 +165,14 @@ except dx.ValidationError as exc:
 
 Each entry has:
 
-- `loc`: a tuple of strings naming the location. For per-field
-  validators this is `(field_name,)`; for cross-field axioms it is
-  `()`.
-- `type`: a discriminator string (`missing_required`, `extra_field`,
-  `type_error`, `validates_failed`, `axiom_failed`).
-- `msg`: a human-readable description.
+- `loc`: a tuple naming the location. For per-field validators this
+  is `(field_name,)`; for cross-field axioms it is `()`.
+- `type`: a discriminator string. `validator_error` means a
+  `@validates` method raised; `type_error` means the encoder
+  rejected the value; `axiom_violation` means an `__axioms__`
+  expression failed; `missing_required`, `extra_field`, and
+  `converter_error` cover the other construction-time failures.
+- `msg`: a human-readable description (the exception message for
+  validator errors).
 
 The set of `type` values is open; new versions may add more.

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.4.1"
+version = "0.4.2"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.4.1"
+version = "0.4.2"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.4.1"
+version = "0.4.2"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.4.1"
+version = "0.4.2"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -348,6 +348,7 @@ class ModelMeta(type):
     __model_config__: ModelConfig
     __computed_fields__: tuple[str, ...]
     __class_axioms__: tuple[Axiom, ...]
+    __field_validators__: dict[str, tuple[tuple[str, str], ...]]
     __theory_cache__: panproto.Theory | None
 
     @property
@@ -397,6 +398,7 @@ class ModelMeta(type):
             cls.__model_config__ = DEFAULT_CONFIG
             cls.__computed_fields__ = ()
             cls.__class_axioms__ = ()
+            cls.__field_validators__ = {}
             return cls
 
         cls.__schema_kind__ = name
@@ -404,6 +406,7 @@ class ModelMeta(type):
         cls.__field_specs__ = ModelMeta.collect_field_specs(cls)
         cls.__computed_fields__ = computed_field_names(cls)
         cls.__class_axioms__ = collect_class_axioms(cls)
+        cls.__field_validators__ = ModelMeta.collect_field_validators(cls)
         # placeholder for the cached panproto.Theory; populated lazily
         # by the `__theory__` property the metaclass exposes below.
         cls.__theory_cache__ = None
@@ -540,6 +543,65 @@ class ModelMeta(type):
                     seen[fname] = spec
 
         return seen
+
+    @staticmethod
+    def collect_field_validators(
+        target: type,
+    ) -> dict[str, tuple[tuple[str, str], ...]]:
+        """Walk MRO and collect ``@validates``-tagged methods.
+
+        Parameters
+        ----------
+        target
+            The class to inspect.
+
+        Returns
+        -------
+        dict
+            Mapping ``field_name -> tuple of (method_name, mode)`` in
+            registration order. Methods are stored by name (not bound
+            callable) so that subclasses overriding a validator method
+            transparently take effect: ``getattr(cls, method_name)`` at
+            call time picks up the override via normal MRO.
+
+        Notes
+        -----
+        Walks ``target.__mro__`` in reverse so subclass declarations
+        override ancestor declarations. A subclass method that shadows
+        an ancestor validator *without* re-applying ``@validates``
+        unregisters that method's marker; the override is taken at face
+        value.
+        """
+        # method_name -> marker dict, populated in reverse-MRO order so
+        # the subclass entry wins. Subclass methods that shadow without
+        # the marker remove the ancestor entry.
+        markers: dict[str, dict[str, Opaque]] = {}
+        for klass in reversed(target.__mro__):
+            if not isinstance(klass, ModelMeta):
+                continue
+            for member_name, member in vars(klass).items():
+                if member_name.startswith("__"):
+                    continue
+                marker = getattr(member, "__didactic_validator__", None)
+                if marker is None:
+                    func = getattr(member, "__func__", None)
+                    if func is not None:
+                        marker = getattr(func, "__didactic_validator__", None)
+                if marker is not None:
+                    markers[member_name] = cast("dict[str, Opaque]", marker)
+                elif callable(member) and member_name in markers:
+                    # subclass shadows the ancestor validator without
+                    # re-tagging; honour the override and drop the marker
+                    del markers[member_name]
+
+        # invert to per-field tuples, preserving registration order
+        per_field: dict[str, list[tuple[str, str]]] = {}
+        for member_name, marker in markers.items():
+            field_names = cast("tuple[str, ...]", marker["fields"])
+            mode = cast("str", marker["mode"])
+            for fname in field_names:
+                per_field.setdefault(fname, []).append((member_name, mode))
+        return {fname: tuple(items) for fname, items in per_field.items()}
 
 
 __all__ = [

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -22,10 +22,13 @@ didactic.models._storage : the pluggable storage backend.
 """
 
 # ``__init__(**kwargs: FieldValue | JsonValue)`` accepts JSON-shape
-# dicts but pyright doesn't carry the union through ``_encode_field``.
+# dicts but pyright doesn't carry the union through the field
+# pipeline; the per-call ``cast("FieldValue", value)`` covers this.
 from __future__ import annotations
 
+import inspect
 import json
+from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
 from types import UnionType
@@ -51,7 +54,7 @@ from didactic.models._meta import ModelMeta, read_class_annotations
 from didactic.models._storage import DictStorage
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from didactic.axioms._axioms import Axiom
     from didactic.codegen._json_schema import JsonSchemaDoc
@@ -180,7 +183,18 @@ class Model(metaclass=ModelMeta):
                 value = default
 
             try:
-                encoded_value = _encode_field(spec, cast("FieldValue", value))
+                encoded_value = _run_field_pipeline(
+                    cls, spec, fname, cast("FieldValue", value)
+                )
+            except _ValidatorError as fail:
+                errors.append(
+                    ValidationErrorEntry(
+                        loc=(fname,),
+                        type="validator_error",
+                        msg=fail.message,
+                    )
+                )
+                continue
             except (TypeError, ValueError) as exc:
                 errors.append(
                     ValidationErrorEntry(
@@ -319,7 +333,13 @@ class Model(metaclass=ModelMeta):
                 )
                 continue
             try:
-                encoded[k] = _encode_field(specs[k], v)
+                encoded[k] = _run_field_pipeline(cls, specs[k], k, v)
+            except _ValidatorError as fail:
+                errors.append(
+                    ValidationErrorEntry(
+                        loc=(k,), type="validator_error", msg=fail.message
+                    )
+                )
             except (TypeError, ValueError) as exc:
                 errors.append(
                     ValidationErrorEntry(loc=(k,), type="type_error", msg=str(exc))
@@ -1031,15 +1051,56 @@ def _from_json_payload(
     return out
 
 
-def _encode_field(spec: FieldSpec, value: FieldValue) -> Encoded:
-    """Run the converter (if any) and the type-translation encoder.
+@dataclass(frozen=True, slots=True)
+class _ValidatorError(Exception):
+    """Internal error type carrying a ``@validates``-raised message.
+
+    Wraps the ``ValueError`` / ``TypeError`` raised by a user
+    validator so the ``__init__`` and ``with_()`` paths can route the
+    failure to a ``"validator_error"`` ``ValidationErrorEntry``
+    instead of conflating it with the encoder's ``"type_error"``.
+    """
+
+    message: str
+
+
+def _invoke_validator(cls: type, method_name: str, value: FieldValue) -> FieldValue:
+    """Invoke a ``@validates``-tagged method with class-level binding.
+
+    Both ``@classmethod`` and plain instance methods are supported.
+    Instance methods receive the class as their first argument (the
+    Model is frozen and not yet constructed when validators run, so
+    no instance ``self`` exists). ``@staticmethod`` validators are
+    called with the value alone.
+    """
+    descriptor = inspect.getattr_static(cls, method_name)
+    if isinstance(descriptor, staticmethod):
+        sm = cast("staticmethod[..., FieldValue]", descriptor)
+        return sm.__func__(value)
+    if isinstance(descriptor, classmethod):
+        cm = cast("classmethod[type, ..., FieldValue]", descriptor)
+        return cm.__func__(cls, value)
+    return cast("Callable[..., FieldValue]", descriptor)(cls, value)
+
+
+def _run_field_pipeline(
+    cls: type,
+    spec: FieldSpec,
+    fname: str,
+    value: FieldValue,
+) -> Encoded:
+    """Run converter, before-validators, encoder, after-validators.
 
     Parameters
     ----------
+    cls
+        The Model class (used to look up validators and bind them).
     spec
         The field's spec.
+    fname
+        Field name; used to find registered validators.
     value
-        The user-supplied value.
+        The raw user-supplied value (or the resolved default).
 
     Returns
     -------
@@ -1048,12 +1109,49 @@ def _encode_field(spec: FieldSpec, value: FieldValue) -> Encoded:
 
     Raises
     ------
+    _ValidatorError
+        A ``@validates`` callback raised ``ValueError`` or ``TypeError``.
     TypeError or ValueError
-        If the value cannot be encoded.
+        The encoder rejected the value (mismatched type, failed
+        ``Annotated[...]`` constraint, etc.).
     """
     if spec.converter is not None:
         value = spec.converter(value)
-    return spec.translation.encode(value)
+
+    validators: tuple[tuple[str, str], ...] = cast(
+        "ModelMeta", cls
+    ).__field_validators__.get(fname, ())
+
+    for method_name, mode in validators:
+        if mode != "before":
+            continue
+        try:
+            value = _invoke_validator(cls, method_name, value)
+        except (ValueError, TypeError) as exc:
+            raise _ValidatorError(str(exc)) from exc
+
+    encoded_value = spec.translation.encode(value)
+
+    if not any(mode == "after" for _, mode in validators):
+        return encoded_value
+
+    # ``after`` validators see the canonical decoded form, mirroring
+    # Pydantic's behaviour where the post-coercion value is what the
+    # validator inspects. Re-encode if any validator returned a
+    # different value.
+    typed: FieldValue = spec.translation.decode(encoded_value)
+    new_value = typed
+    for method_name, mode in validators:
+        if mode != "after":
+            continue
+        try:
+            new_value = _invoke_validator(cls, method_name, new_value)
+        except (ValueError, TypeError) as exc:
+            raise _ValidatorError(str(exc)) from exc
+
+    if new_value is typed:
+        return encoded_value
+    return spec.translation.encode(new_value)
 
 
 # alias for adoption ergonomics

--- a/packages/didactic/tests/test_validators.py
+++ b/packages/didactic/tests/test_validators.py
@@ -1,0 +1,204 @@
+"""Tests for the ``@dx.validates`` decorator end-to-end.
+
+Covers the metaclass collection of ``@validates``-tagged methods, the
+runtime invocation pipeline (before / after, value mutation,
+ValidationError shape), inheritance and override semantics, and the
+three method shapes (instance, classmethod, staticmethod).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import didactic.api as dx
+
+
+# -- after-mode validators -------------------------------------------------
+
+
+class _NameModel(dx.Model):
+    name: str
+
+    @dx.validates("name")
+    def _check_name(self, value: str) -> str:
+        if not value.strip():
+            msg = "name cannot be empty"
+            raise ValueError(msg)
+        return value.strip()
+
+
+def test_after_validator_runs_and_replaces_value() -> None:
+    """An ``after`` validator's return value replaces the stored value."""
+    m = _NameModel(name="  alice  ")
+    assert m.name == "alice"
+
+
+def test_after_validator_raises_validation_error() -> None:
+    """A validator's ``raise ValueError`` surfaces as ``ValidationError``."""
+    with pytest.raises(dx.ValidationError) as exc:
+        _NameModel(name="")
+    entries = exc.value.entries
+    assert len(entries) == 1
+    assert entries[0].loc == ("name",)
+    assert entries[0].type == "validator_error"
+    assert "empty" in entries[0].msg
+
+
+def test_after_validator_runs_on_with_too() -> None:
+    """``with_(...)`` runs the same validator pipeline."""
+    m = _NameModel(name="alice")
+    with pytest.raises(dx.ValidationError):
+        m.with_(name="")
+
+
+# -- before-mode validators ------------------------------------------------
+
+
+class _NormalisedEmail(dx.Model):
+    email: str
+
+    @dx.validates("email", mode="before")
+    def _normalise(self, value: str) -> str:
+        return value.lower()
+
+
+def test_before_validator_runs_before_encoding() -> None:
+    """A ``before`` validator's output is what gets type-validated and stored."""
+    m = _NormalisedEmail(email="ALICE@EXAMPLE.COM")
+    assert m.email == "alice@example.com"
+
+
+# -- @classmethod form (matches the decorator's docstring example) ---------
+
+
+class _LowerEmail(dx.Model):
+    email: str
+
+    @dx.validates("email")
+    @classmethod
+    def _email_lower(cls, value: str) -> str:
+        # the cls argument actually receives the class
+        assert cls is _LowerEmail
+        return value.lower()
+
+
+def test_classmethod_validator_form() -> None:
+    m = _LowerEmail(email="BOB@EXAMPLE.COM")
+    assert m.email == "bob@example.com"
+
+
+# -- @staticmethod form ----------------------------------------------------
+
+
+class _TrimEmail(dx.Model):
+    email: str
+
+    @dx.validates("email")
+    @staticmethod
+    def _trim(value: str) -> str:
+        return value.strip()
+
+
+def test_staticmethod_validator_form() -> None:
+    m = _TrimEmail(email="  c@d.e  ")
+    assert m.email == "c@d.e"
+
+
+# -- multiple fields share a single validator ------------------------------
+
+
+class _Pair(dx.Model):
+    first: str
+    last: str
+
+    @dx.validates("first", "last")
+    def _trim(self, value: str) -> str:
+        return value.strip()
+
+
+def test_one_validator_for_multiple_fields() -> None:
+    m = _Pair(first="  a  ", last="  b  ")
+    assert (m.first, m.last) == ("a", "b")
+
+
+# -- inheritance -----------------------------------------------------------
+
+
+class _BaseV(dx.Model):
+    name: str
+
+    @dx.validates("name")
+    def _strip(self, value: str) -> str:
+        return value.strip()
+
+
+class _ChildV(_BaseV):
+    pass
+
+
+def test_subclass_inherits_validator() -> None:
+    m = _ChildV(name="  z  ")
+    assert m.name == "z"
+
+
+class _ChildOverride(_BaseV):
+    @dx.validates("name")
+    def _strip(self, value: str) -> str:
+        return value.strip().upper()
+
+
+def test_subclass_can_override_validator_with_new_marker() -> None:
+    m = _ChildOverride(name="  z  ")
+    assert m.name == "Z"
+
+
+class _ChildSilentlyShadow(_BaseV):
+    # subclass shadows the validator method WITHOUT re-applying @validates;
+    # the subclass intent is "stop validating", and the runtime honours it.
+    def _strip(self, value: str) -> str:  # type: ignore[override]
+        return value
+
+
+def test_subclass_method_without_marker_unregisters_validator() -> None:
+    m = _ChildSilentlyShadow(name="  z  ")
+    assert m.name == "  z  "
+
+
+# -- composition with converter and Annotated constraints -----------------
+
+
+class _WithConverter(dx.Model):
+    code: str = dx.field(converter=lambda v: str(v).upper())
+
+    @dx.validates("code")
+    def _check(self, value: str) -> str:
+        # converter runs first, so we always see uppercase here
+        if not value.isupper():
+            msg = "must be upper after converter"
+            raise ValueError(msg)
+        return value
+
+
+def test_validator_runs_after_converter() -> None:
+    m = _WithConverter(code="abc")
+    assert m.code == "ABC"
+
+
+# -- multiple validators on one field run in registration order ------------
+
+
+class _Chain(dx.Model):
+    word: str
+
+    @dx.validates("word")
+    def _strip(self, value: str) -> str:
+        return value.strip()
+
+    @dx.validates("word")
+    def _upper(self, value: str) -> str:
+        return value.upper()
+
+
+def test_multiple_validators_chain_in_order() -> None:
+    m = _Chain(word="  hi  ")
+    assert m.word == "HI"

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

`@dx.validates` was a silent no-op: the decorator stamped a marker on
the method, but no consumer ever read it. The metaclass didn't scan
for it; `Model.__init__` and `Model.with_(...)` didn't invoke any
per-field validator. Every validator-decorated method in every
codebase was dead weight, and bad input got through with no error.

This PR wires the missing half: the metaclass collects validators
into `__field_validators__` on each class, the construction and
`with_(...)` paths run them in the right order, and validator
failures surface as `ValidationError` entries with a new
`type="validator_error"` discriminator. Closes #17.

## Motivation

Surfaced while migrating `bead` from Pydantic. Every model with
non-empty-string checks (`UnfilledSlot.slot_name`,
`ModelOutput.{model_name,model_version,operation,cache_key}`,
`SpanLabel.label`, `SpanSegment.{element_name,indices}`,
`ItemTemplate.name`, `ItemTemplateCollection.name`, etc.) silently
accepted empty input under didactic 0.4.1. Migrating from Pydantic's
`@field_validator` is the natural Python-side path for cross-field
cleanup, length checks, regex matches, normalisation; without
working `@dx.validates`, every Pydantic codebase migrating to
didactic loses validators silently.

## Changes

- `packages/didactic/src/didactic/models/_meta.py` — adds the
  `__field_validators__` class attribute and a static
  `collect_field_validators` that walks `target.__mro__` for the
  `__didactic_validator__` marker. Stores per-field tuples of
  `(method_name, mode)` so subclass overrides take effect through
  normal MRO at call time. Subclass shadow without `@validates`
  unregisters the inherited marker.
- `packages/didactic/src/didactic/models/_model.py` — adds
  `_run_field_pipeline` (converter -> before validators -> encode ->
  after validators on the canonical decoded value -> re-encode if
  changed), `_invoke_validator` (dispatches on `staticmethod` /
  `classmethod` / plain function; instance methods receive `cls`
  since the Model is frozen and not yet constructed), and a new
  `_ValidatorError` internal exception that routes failures to
  `type="validator_error"` `ValidationErrorEntry`s in both
  `Model.__init__` and `Model.with_(...)`.
- `packages/didactic/tests/test_validators.py` (new) — 12 tests
  covering after/before modes, the three method shapes, multi-field
  validators, multi-validator chaining, inheritance, override,
  silent-shadow disable, and converter ordering.
- `docs/guide/validators.md` — rewritten. The previous draft
  documented a `return bool` shape the runtime never implemented;
  the new guide covers the actual `raise ValueError` /
  return-value-replaces-stored-value contract, `before` vs `after`
  mode, the three method shapes, inheritance, and the new
  `validator_error` discriminator.
- All four packages bumped to 0.4.2 (`pyproject.toml` +
  `__version__`).
- `CHANGELOG.md` — `[0.4.2] - 2026-05-05` entry.

## Tests

536 tests pass (12 new, all in the new `test_validators.py`). The
new tests cover both the metaclass collection layer (inheritance,
override, silent-shadow disable) and the runtime invocation path
(after/before modes, the three method shapes, multi-field, chaining,
converter ordering, ValidationError shape on raise).

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (536 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Behaviour change** — existing public API behaves differently.
  Code that *had* a `@dx.validates`-decorated method which silently
  did nothing will now actually run the method. Inputs the dead
  validators would have rejected (had they run) will now raise
  `dx.ValidationError`. The migration path is "your `@validates`
  methods now do what their docstring claimed they did" — codebases
  that relied on the silent-no-op behaviour will have to reckon with
  invalid inputs they were quietly accepting.

  No change to method signatures: instance, `@classmethod`, and
  `@staticmethod` shapes all work; instance methods receive the
  class as their first argument (no `self` exists during
  construction).

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.4.2]`.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #17.