### PR TITLE
fix(unions): TaggedUnion accepts qualified Literal spellings (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-05
+
+### Fixed
+
+- ``dx.TaggedUnion`` variant discriminator now accepts every spelling
+  of ``Literal[...]``: bare ``Literal["x"]``, qualified
+  ``typing.Literal["x"]``, and aliased imports
+  (``from typing import Literal as L``). Under
+  ``from __future__ import annotations`` the discriminator
+  annotation arrives as a string; the variant check now evaluates
+  that string in the class's defining module before applying the
+  ``get_origin(...) is Literal`` check, instead of pattern-matching
+  on the source text. Useful when the variant Model has a class
+  also named ``Literal`` (e.g. an AST module exporting ``Literal``,
+  ``Variable``, ``BinaryOp`` from a discriminator-tagged ``ASTNode``
+  union root) so the user can keep the public API name. ([#18])
+
+[#18]: https://github.com/panproto/didactic/issues/18
+
 ## [0.4.2] - 2026-05-05
 
 ### Fixed

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.4.2"
+version = "0.4.3"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.4.2"
+version = "0.4.3"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.4.2"
+version = "0.4.3"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.4.2"
+version = "0.4.3"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/fields/_unions.py
+++ b/packages/didactic/src/didactic/fields/_unions.py
@@ -44,7 +44,16 @@ didactic.models._meta.ModelMeta : the metaclass; unchanged.
 from __future__ import annotations
 
 import annotationlib
-from typing import TYPE_CHECKING, ClassVar, Literal, Self, cast, get_args, get_origin
+import sys
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Literal,
+    Self,
+    cast,
+    get_args,
+    get_origin,
+)
 
 from didactic.fields._validators import ValidationError, ValidationErrorEntry
 from didactic.models._model import Model
@@ -139,6 +148,12 @@ class TaggedUnion(Model):
         # NOTE: we read annotations directly here rather than through the
         # metaclass's `__field_specs__` because `__init_subclass__` fires
         # *during* the metaclass's __new__, before __field_specs__ is set.
+        # FORWARDREF gives us un-evaluated forms when the class uses
+        # ``from __future__ import annotations``; the discriminator field
+        # is then re-resolved in the class's defining module so qualified
+        # spellings (``typing.Literal[...]``) and aliased imports
+        # (``from typing import Literal as L``) are handled the same as
+        # the bare ``Literal[...]`` form.
         annotations = annotationlib.get_annotations(
             cls,
             format=annotationlib.Format.FORWARDREF,
@@ -150,12 +165,16 @@ class TaggedUnion(Model):
             )
             raise TypeError(msg)
 
+        disc_annotation = _resolve_discriminator_annotation(
+            cls, annotations[disc_field]
+        )
+
         # extract the Literal value(s)
-        values = _literal_values(annotations[disc_field])
+        values = _literal_values(disc_annotation)
         if not values:
             msg = (
                 f"variant {cls.__name__}.{disc_field} must be annotated as "
-                f"Literal[...] with at least one value; got {annotations[disc_field]!r}"
+                f"Literal[...] with at least one value; got {disc_annotation!r}"
             )
             raise TypeError(msg)
 
@@ -250,6 +269,40 @@ def _literal_values(annotation: Opaque) -> tuple[FieldValue, ...]:
     if get_origin(annotation) is Literal:
         return get_args(annotation)
     return ()
+
+
+def _resolve_discriminator_annotation(cls: type, raw: Opaque) -> Opaque:
+    """Return the live annotation object for ``cls.disc_field``.
+
+    Under ``from __future__ import annotations`` (or any context where
+    the class's ``__annotations__`` carries strings), the raw entry
+    will not satisfy ``get_origin(...) is Literal``. Evaluate the
+    string in the class's defining module so qualified spellings
+    (``typing.Literal[...]``), aliased imports
+    (``from typing import Literal as L``), and bare ``Literal[...]``
+    all reach the same live ``Literal`` object.
+
+    Only the discriminator's own annotation is evaluated; other
+    fields on the class may legitimately carry forward references
+    that don't resolve at class-creation time, and resolving them
+    here would mask those into spurious failures of this check.
+
+    The raw annotation is returned unchanged when evaluation fails;
+    the caller surfaces the original value in the error message,
+    which is friendlier than a stray ``NameError``.
+    """
+    if get_origin(raw) is Literal:
+        return raw
+    if not isinstance(raw, str):
+        return raw
+    module = sys.modules.get(getattr(cls, "__module__", ""))
+    if module is None:
+        return raw
+    try:
+        evaluated = eval(raw, vars(module))
+    except Exception:
+        return raw
+    return cast("Opaque", evaluated)
 
 
 __all__ = [

--- a/packages/didactic/tests/test_tagged_union_qualified_literal.py
+++ b/packages/didactic/tests/test_tagged_union_qualified_literal.py
@@ -1,0 +1,61 @@
+"""Variant discriminator accepts every spelling of ``Literal[...]``.
+
+Covers the qualified spelling (``typing.Literal[...]``), aliased
+imports (``from typing import Literal as Other``), and the form
+under ``from __future__ import annotations``. The discriminator
+check used to do a string compare on the annotation source, so any
+spelling that didn't render as ``Literal[...]`` was rejected; this
+file pins the typing-introspection contract that replaced it.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import Literal as Lit
+
+import pytest
+
+import didactic.api as dx
+
+
+class _Node(dx.TaggedUnion, discriminator="kind"):
+    pass
+
+
+class _LitNode(_Node):
+    kind: typing.Literal["lit"]
+    value: int
+
+
+class _VarNode(_Node):
+    kind: Lit["var"]
+    name: str
+
+
+def test_qualified_literal_registers_variant() -> None:
+    assert _Node.__variants__["lit"] is _LitNode
+    inst = _LitNode(kind="lit", value=42)
+    assert inst.value == 42
+
+
+def test_aliased_literal_import_registers_variant() -> None:
+    assert _Node.__variants__["var"] is _VarNode
+    inst = _VarNode(kind="var", name="x")
+    assert inst.name == "x"
+
+
+def test_dispatch_through_root_for_qualified_literal() -> None:
+    instance = _Node.model_validate({"kind": "lit", "value": 7})
+    assert isinstance(instance, _LitNode)
+    assert instance.value == 7
+
+
+def test_non_literal_discriminator_still_rejected() -> None:
+    """The fix only relaxes the *spelling* check; non-Literal still fails."""
+    with pytest.raises(TypeError, match="must be annotated as Literal"):
+
+        class _Bad(_Node):
+            kind: str  # not a Literal at all
+            extra: int
+
+        _ = _Bad  # silence "unused class" lint; the TypeError prevents creation


### PR DESCRIPTION
## Summary

Variant declarations under ``from __future__ import annotations`` failed
the discriminator check whenever the ``Literal`` was spelled as
anything other than the bare ``Literal[...]`` import (qualified
``typing.Literal[...]``, aliased ``from typing import Literal as L``).
Closes #18.

## Motivation

Surfaced converting `bead/dsl/ast.py`. The module exports a public
class named ``Literal`` alongside other AST node classes
(``Variable``, ``BinaryOp``, ...), all inheriting from a
discriminator-tagged ``ASTNode`` union root. The class name predates
the migration and is exported from `bead.dsl`; renaming it has wide
caller blast radius. The natural workaround is
``from typing import Literal as L``, which currently fails:

```
TypeError: variant Lit.kind must be annotated as Literal[...] with at least one value;
got "typing.Literal['lit']"
```

## Changes

- `packages/didactic/src/didactic/fields/_unions.py` — adds
  `_resolve_discriminator_annotation(cls, raw)`. When the
  discriminator annotation arrives as a string (PEP 563 / future-
  annotations), evaluate it in the class's defining module before
  applying `get_origin(...) is Literal`. Only the discriminator's
  own annotation is evaluated; using `typing.get_type_hints(cls)`
  would walk every annotation on the class and surface spurious
  `NameError` for unrelated forward references.
- `packages/didactic/tests/test_tagged_union_qualified_literal.py`
  (new) — 4 tests under `from __future__ import annotations`
  covering qualified spelling, aliased import, dispatch through
  the root, and the non-Literal-still-rejected guarantee.
- `CHANGELOG.md` — `[0.4.3] - 2026-05-05` entry.
- All four package versions bumped to 0.4.3.

## Tests

540 tests pass (4 new). The new file is the first test module that
explicitly enables `from __future__ import annotations` to exercise
the string-annotation path through the variant check.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (540 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible addition** — the previously-rejected
  qualified and aliased spellings now register correctly. No
  spelling that previously worked breaks. Non-Literal discriminators
  (e.g. ``kind: str``) still raise the same ``TypeError`` as before.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.4.3]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #18.