### PR TITLE
feat: Path/Enum scalars + recursive TaggedUnion fixes (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-05
+
+### Added
+
+- ``pathlib.Path`` (and any ``PurePath`` subclass: ``PurePosixPath``,
+  ``PureWindowsPath``, etc.) is a first-class scalar field type. Wire
+  format is ``str(path)``; decoding restores the same ``PurePath``
+  subclass. ([#21])
+- ``enum.StrEnum`` and ``enum.IntEnum`` are first-class scalar field
+  types. String-valued and int-valued plain ``enum.Enum`` subclasses
+  also work; mixed-value enums raise ``TypeNotSupportedError``. The
+  encoder accepts either an enum member or its raw value, so
+  ``M.model_validate({"color": "red"})`` works the same as
+  ``M(color=Color.RED)``. ([#23])
+
+### Fixed
+
+- TaggedUnion-typed fields now JSON-round-trip correctly when the
+  variant is itself a TaggedUnion. ``model_validate_json`` walks
+  each nested ``{"kind": "...", ...}`` payload through the
+  discriminator registry, instead of handing the dict straight to
+  the variant-encoder (which expected a fully-constructed instance).
+  Direct construction with a dict child works too:
+  ``BinOp(left={"kind": "lit", "value": 1}, ...)`` dispatches the
+  same way. ([#22])
+- TaggedUnion-typed fields consult ``cls.__variants__`` *live* at
+  encode and decode time, not snapshotted at field-classify time.
+  Variants registered after a parent variant's field was classified
+  (the canonical case is mutually recursive AST shapes:
+  ``BinaryOp`` -> ``ListLiteral`` and ``ListLiteral`` -> ``BinaryOp``)
+  participate fully, in either definition order. ([#24])
+
+### Changed
+
+- ``docs/guide/types.md`` documents the Path family and the
+  StrEnum / IntEnum / value-typed Enum branches alongside a
+  worked ``StrEnum`` example.
+- ``docs/guide/unions.md`` documents recursive and mutually
+  recursive variants, dict-dispatch on construction, and the JSON
+  round-trip contract.
+
+[#21]: https://github.com/panproto/didactic/issues/21
+[#22]: https://github.com/panproto/didactic/issues/22
+[#23]: https://github.com/panproto/didactic/issues/23
+[#24]: https://github.com/panproto/didactic/issues/24
+
 ## [0.4.3] - 2026-05-05
 
 ### Fixed

--- a/docs/guide/types.md
+++ b/docs/guide/types.md
@@ -26,12 +26,45 @@ Mutable containers (`list`, `set`, plain `dict`) are rejected. Use
 | `datetime.timedelta` | seconds | `timedelta` |
 | `decimal.Decimal` | numeric string | `Decimal` |
 | `uuid.UUID` | canonical | `UUID` |
-| `pathlib.Path` | string | `Path` |
-| `enum.Enum` | member name | `Enum` |
+| `pathlib.Path` (and any `PurePath` subclass) | string | the same `PurePath` subclass |
+| `enum.StrEnum` | string (the member value) | `StrEnum` member |
+| `enum.IntEnum` | integer (the member value) | `IntEnum` member |
+| `enum.Enum` (string- or int-valued) | the member value | `Enum` member |
 
 The encoded form is what panproto stores. JSON output uses the same
 encoded form, with one extra step that turns hex `bytes` into a
 JSON string and `frozenset` into a sorted list.
+
+## Paths and enums
+
+`pathlib.Path` and any `PurePath` subclass round-trip as strings:
+
+```python
+from pathlib import Path
+
+class Cfg(dx.Model):
+    data_dir: Path
+```
+
+`enum.StrEnum` round-trips as a string (the member value);
+`enum.IntEnum` round-trips as an integer. Plain `enum.Enum` works
+when every member's value is a string or every member's value is an
+integer; mixed-value enums raise `TypeNotSupportedError`.
+
+```python
+from enum import StrEnum
+
+class Color(StrEnum):
+    RED = "red"
+    BLUE = "blue"
+
+class Item(dx.Model):
+    color: Color
+```
+
+Construction accepts either an enum member or its raw value, so
+`Item.model_validate({"color": "red"})` works the same as
+`Item(color=Color.RED)`.
 
 ## Optional types
 

--- a/docs/guide/unions.md
+++ b/docs/guide/unions.md
@@ -59,6 +59,54 @@ Shape.__variants__
 This is the surface code-generation tools and schema-diff tools read
 when emitting the union.
 
+## Recursive and mutually recursive variants
+
+A variant may carry the union root as a field type:
+
+```python
+from typing import Literal
+
+class Node(dx.TaggedUnion, discriminator="kind"):
+    pass
+
+class Lit(Node):
+    kind: Literal["lit"]
+    value: int
+
+class BinOp(Node):
+    kind: Literal["binop"]
+    op: str
+    left: Node       # the union itself, not a specific variant
+    right: Node
+
+class ListLit(Node):     # registered after BinOp
+    kind: Literal["list_lit"]
+    elements: tuple[int, ...] = ()
+```
+
+The variant registry is consulted *live* at encode and decode time,
+so a variant declared later (here `ListLit`) is a legal child of an
+earlier variant's union-typed field. Mutually recursive AST shapes
+work: any variant can sit inside any other variant's union-typed
+field, regardless of declaration order.
+
+Construction accepts both fully-built variant instances and dict
+payloads carrying the discriminator:
+
+```python
+BinOp(
+    kind="binop",
+    op="+",
+    left={"kind": "lit", "value": 1},   # dict dispatches via discriminator
+    right=Lit(kind="lit", value=2),
+)
+```
+
+`model_dump_json` / `model_validate_json` round-trip recursive
+unions: nested variants are written as their natural JSON shape
+(the discriminator key is the constructor tag) and reconstructed by
+dispatching each child dict through the live variant registry.
+
 ## Limitations
 
 Discriminator values must be string literals. Non-string discriminators

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.4.3"
+version = "0.5.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.4.3"
+version = "0.5.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.4.3"
+version = "0.5.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.4.3"
+version = "0.5.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -26,11 +26,13 @@ didactic.models._storage : the pluggable storage backend.
 # pipeline; the per-call ``cast("FieldValue", value)`` covers this.
 from __future__ import annotations
 
+import enum
 import inspect
 import json
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
+from pathlib import PurePath
 from types import UnionType
 from typing import (
     TYPE_CHECKING,
@@ -1005,6 +1007,10 @@ def _to_json_safe(value: FieldValue | JsonValue) -> JsonValue:
         return str(value)
     if isinstance(value, bytes):
         return value.hex()
+    if isinstance(value, PurePath):
+        return str(value)
+    if isinstance(value, enum.Enum):
+        return cast("JsonValue", value.value)
     if isinstance(value, Model):
         # embedded sub-model; recurse into its model_dump shape
         return _to_json_safe(value.model_dump())

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -30,11 +30,13 @@ didactic.models._meta : the metaclass that orchestrates field translation.
 # narrows to the wider ``object`` carve-out branch.
 from __future__ import annotations
 
+import enum
 import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
 from functools import reduce
+from pathlib import PurePath
 from types import EllipsisType, GenericAlias, NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
@@ -313,11 +315,143 @@ _SCALARS: dict[
 
 
 def _is_scalar(typ: TypeForm) -> bool:
-    return isinstance(typ, type) and typ in _SCALARS
+    if not isinstance(typ, type):
+        return False
+    cls = cast("type[object]", typ)
+    if cls in _SCALARS:
+        return True
+    if issubclass(cls, PurePath):
+        return True
+    return _enum_kind(cls) is not None
 
 
 def _scalar_translation(typ: type) -> TypeTranslation:
-    sort, enc, dec, from_json = _SCALARS[typ]
+    cls = cast("type[object]", typ)
+    if cls in _SCALARS:
+        sort, enc, dec, from_json = _SCALARS[cls]
+        return TypeTranslation(
+            sort=sort,
+            encode=enc,
+            decode=dec,
+            inner_kind="scalar",
+            from_json=from_json,
+        )
+    if issubclass(cls, PurePath):
+        return _path_translation(cls)
+    enum_kind = _enum_kind(cls)
+    if enum_kind is not None:
+        return _enum_translation(cls, enum_kind)
+    msg = f"Type {cls!r} is not a registered scalar."
+    raise TypeNotSupportedError(msg)
+
+
+def _path_translation(typ: type) -> TypeTranslation:
+    """Translate ``pathlib.Path`` (and any ``PurePath`` subclass).
+
+    Wire format is ``str(path)``; decoding restores the same subclass.
+    """
+
+    def enc(v: FieldValue) -> Encoded:
+        if not isinstance(v, PurePath):
+            msg = f"expected PurePath for Path field, got {type(v).__name__}"
+            raise TypeError(msg)
+        return str(v)
+
+    def dec(s: Encoded) -> FieldValue:
+        return cast("FieldValue", typ(s))
+
+    def from_json(v: JsonValue) -> FieldValue:
+        if not isinstance(v, str):
+            msg = f"expected JSON string for Path field, got {type(v).__name__}"
+            raise TypeError(msg)
+        return cast("FieldValue", typ(v))
+
+    return TypeTranslation(
+        sort="Path",
+        encode=enc,
+        decode=dec,
+        inner_kind="scalar",
+        from_json=from_json,
+    )
+
+
+def _enum_kind(typ: type) -> Literal["str", "int"] | None:
+    """Classify an Enum subclass as string- or integer-valued.
+
+    Returns ``"str"`` for ``StrEnum`` (or any ``Enum`` whose member
+    values are all ``str``), ``"int"`` for ``IntEnum`` (or any
+    ``Enum`` whose member values are all ``int``), and ``None``
+    otherwise (the enum is rejected at classify time, with a message
+    that points to the supported shapes).
+    """
+    if not issubclass(typ, enum.Enum):
+        return None
+    if issubclass(typ, enum.StrEnum):
+        return "str"
+    if issubclass(typ, enum.IntEnum):
+        return "int"
+    members = list(typ)
+    if not members:
+        return None
+    if all(isinstance(m.value, bool) for m in members):
+        # ``bool`` is a subclass of ``int``; reject so the user
+        # isn't surprised by True/False round-tripping as 1/0.
+        return None
+    if all(isinstance(m.value, str) for m in members):
+        return "str"
+    if all(isinstance(m.value, int) for m in members):
+        return "int"
+    return None
+
+
+def _enum_translation(typ: type, kind: Literal["str", "int"]) -> TypeTranslation:
+    """Translate an ``enum.Enum`` subclass as ``String`` or ``Int``.
+
+    The wire format is the member's ``value`` (a ``str`` for
+    ``StrEnum`` / string-valued enums, an ``int`` for ``IntEnum`` /
+    int-valued enums). Decode reconstructs the member via
+    ``EnumCls(value)``, raising ``ValueError`` if the value isn't a
+    registered member.
+    """
+    sort = "String" if kind == "str" else "Int"
+    enum_cls = cast("type[enum.Enum]", typ)
+
+    def enc(v: FieldValue) -> Encoded:
+        # Accept either an enum member or its raw value (matches
+        # Pydantic; lets ``model_validate({"color": "red"})`` work
+        # without the caller having to wrap in ``EnumCls(...)`` first).
+        member: enum.Enum
+        if isinstance(v, enum_cls):
+            member = v
+        else:
+            try:
+                member = enum_cls(v)
+            except (ValueError, TypeError) as exc:
+                msg = f"value {v!r} is not a member or value of {enum_cls.__name__}"
+                raise TypeError(msg) from exc
+        if kind == "str":
+            return json.dumps(member.value)
+        return json.dumps(int(member.value))
+
+    def dec(s: Encoded) -> FieldValue:
+        raw = json.loads(s)
+        return cast("FieldValue", enum_cls(raw))
+
+    def from_json(v: JsonValue) -> FieldValue:
+        if kind == "str":
+            if not isinstance(v, str):
+                msg = (
+                    f"expected JSON string for {enum_cls.__name__}, "
+                    f"got {type(v).__name__}"
+                )
+                raise TypeError(msg)
+        elif not isinstance(v, int) or isinstance(v, bool):
+            msg = (
+                f"expected JSON integer for {enum_cls.__name__}, got {type(v).__name__}"
+            )
+            raise TypeError(msg)
+        return cast("FieldValue", enum_cls(v))
+
     return TypeTranslation(
         sort=sort,
         encode=enc,
@@ -1096,14 +1230,40 @@ def _tagged_union_translation(cls: type) -> TypeTranslation:
     ``cls.__variants__``, and instantiates it via ``model_validate``.
     """
     discriminator = cast("str", cls.__discriminator__)  # type: ignore[attr-defined]
-    variants_by_value: dict[object, type[Model]] = dict(cls.__variants__)  # type: ignore[attr-defined]
     union_name = cls.__name__
-
+    initial_variants = cast(
+        "dict[object, type[Model]]",
+        cls.__variants__,  # type: ignore[attr-defined]
+    )
+    # Snapshot at classify time only for the auxiliary Theory shape;
+    # the runtime encode/decode path reads ``cls.__variants__`` live so
+    # variants registered after this field's classify call (mutually
+    # recursive AST shapes are the canonical case) participate fully.
     aux_sorts, aux_ops = _tagged_union_aux_spec(
-        union_name, discriminator, variants_by_value
+        union_name, discriminator, dict(initial_variants)
     )
 
+    def current_variants() -> dict[object, type[Model]]:
+        live = cast(
+            "dict[object, type[Model]]",
+            cls.__variants__,  # type: ignore[attr-defined]
+        )
+        return dict(live)
+
     def encode_one(value: object) -> JsonValue:
+        variants_by_value = current_variants()
+        # A dict carrying the discriminator is treated as a payload that
+        # would dispatch on ``Root.model_validate``; convert it to the
+        # matching variant instance before the wire dump. Without this,
+        # ``BinOp.model_validate_json`` would hand each nested
+        # ``{"kind": "lit", ...}`` dict straight to this encoder.
+        if isinstance(value, dict) and discriminator in value:
+            payload = cast("dict[str, JsonValue]", value)
+            disc_value = cast("object", payload[discriminator])
+            variant_cls = variants_by_value.get(disc_value)
+            if variant_cls is not None:
+                instance = variant_cls.model_validate_json(json.dumps(payload))
+                return cast("JsonValue", json.loads(instance.model_dump_json()))
         for variant_cls in variants_by_value.values():
             if isinstance(value, variant_cls):
                 # Route through ``model_dump_json`` so any nested
@@ -1111,14 +1271,18 @@ def _tagged_union_translation(cls: type) -> TypeTranslation:
                 # nested-Model fields inside the variant get the
                 # JSON-safe walk that ``model_dump`` alone skips.
                 return cast("JsonValue", json.loads(value.model_dump_json()))
-        variant_names = sorted(v.__name__ for v in variants_by_value.values())
+        variant_names = sorted(
+            cast("type", v).__name__ for v in variants_by_value.values()
+        )
+        value_type_name = type(cast("object", value)).__name__
         msg = (
-            f"value of type {type(value).__name__} is not a registered variant "
+            f"value of type {value_type_name} is not a registered variant "
             f"of TaggedUnion {union_name!r}; expected one of {variant_names}."
         )
         raise TypeError(msg)
 
     def decode_one(payload: JsonValue) -> FieldValue:
+        variants_by_value = current_variants()
         if not isinstance(payload, dict):
             msg = (
                 f"TaggedUnion {union_name!r} payload must be a dict; got "

--- a/packages/didactic/tests/test_enum_field.py
+++ b/packages/didactic/tests/test_enum_field.py
@@ -1,0 +1,88 @@
+"""Tests for ``enum.StrEnum`` / ``enum.IntEnum`` / string- or int-valued
+``enum.Enum`` as field types.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum, StrEnum
+
+import pytest
+
+import didactic.api as dx
+from didactic.types._types import TypeNotSupportedError
+
+
+class _Color(StrEnum):
+    RED = "red"
+    BLUE = "blue"
+
+
+class _Size(IntEnum):
+    S = 1
+    L = 2
+
+
+class _Shape(Enum):
+    CIRCLE = "circle"
+    SQUARE = "square"
+
+
+class _ItemModel(dx.Model):
+    color: _Color
+    size: _Size
+    shape: _Shape
+
+
+def test_strenum_constructs_and_round_trips() -> None:
+    m = _ItemModel(color=_Color.RED, size=_Size.L, shape=_Shape.CIRCLE)
+    payload = m.model_dump_json()
+    assert '"color": "red"' in payload
+    assert '"size": 2' in payload
+    assert '"shape": "circle"' in payload
+    out = _ItemModel.model_validate_json(payload)
+    assert out.color is _Color.RED
+    assert out.size is _Size.L
+    assert out.shape is _Shape.CIRCLE
+
+
+def test_strenum_rejects_unknown_value() -> None:
+    with pytest.raises(dx.ValidationError) as exc:
+        _ItemModel.model_validate({"color": "purple", "size": 1, "shape": "circle"})
+    assert exc.value.entries[0].loc == ("color",)
+
+
+class _IntValued(Enum):
+    A = 1
+    B = 2
+
+
+class _IntValuedHolder(dx.Model):
+    n: _IntValued
+
+
+def test_int_valued_enum_classifies_via_int_branch() -> None:
+    m = _IntValuedHolder(n=_IntValued.A)
+    out = _IntValuedHolder.model_validate_json(m.model_dump_json())
+    assert out == m
+
+
+class _Mixed(Enum):
+    A = "a"
+    B = 2
+
+
+def test_plain_enum_with_mixed_values_rejected() -> None:
+    """Mixed-value ``Enum`` doesn't fit either the str or int branch."""
+    with pytest.raises(TypeNotSupportedError):
+
+        class _M(dx.Model):
+            x: _Mixed
+
+        _ = _M
+
+
+def test_strenum_construct_accepts_member_or_value() -> None:
+    """Construction with the raw value works through the encoder."""
+    m = _ItemModel.model_validate({"color": "blue", "size": 1, "shape": "square"})
+    assert m.color is _Color.BLUE
+    assert m.size is _Size.S

--- a/packages/didactic/tests/test_path_field.py
+++ b/packages/didactic/tests/test_path_field.py
@@ -1,0 +1,73 @@
+"""Tests for ``pathlib.Path`` (and ``PurePath`` family) as field types.
+
+Pydantic accepts ``Path`` natively as a string-shaped field that
+round-trips through ``str(p)`` / ``Path(s)``. didactic mirrors that
+contract so configuration models migrating across don't have to wrap
+every Path-typed field in a property.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+
+import pytest
+
+import didactic.api as dx
+
+
+class _Cfg(dx.Model):
+    data_dir: Path
+    pure: PurePosixPath = PurePosixPath("a/b")
+    optional_log: Path | None = None
+
+
+def test_path_field_constructs() -> None:
+    c = _Cfg(data_dir=Path("/tmp/x"))
+    assert c.data_dir == Path("/tmp/x")
+    assert isinstance(c.data_dir, Path)
+
+
+def test_path_round_trip_through_json() -> None:
+    c = _Cfg(data_dir=Path("/tmp/x"), optional_log=Path("/var/log/a.log"))
+    payload = c.model_dump_json()
+    out = _Cfg.model_validate_json(payload)
+    assert out == c
+    assert isinstance(out.data_dir, Path)
+    assert isinstance(out.optional_log, Path)
+
+
+def test_pure_path_subclass_round_trips_with_subclass() -> None:
+    """``PurePosixPath``-typed field reconstructs as the same subclass."""
+    c = _Cfg(data_dir=Path("/tmp/x"))
+    assert c.pure == PurePosixPath("a/b")
+    assert isinstance(c.pure, PurePosixPath)
+
+
+def test_pure_windows_path_round_trips() -> None:
+    """The path family uses one shared sort, so any ``PurePath`` works."""
+
+    class W(dx.Model):
+        p: PureWindowsPath
+
+    w = W(p=PureWindowsPath(r"C:\\tmp"))
+    out = W.model_validate_json(w.model_dump_json())
+    assert out == w
+    assert isinstance(out.p, PureWindowsPath)
+
+
+def test_path_field_rejects_non_path_input() -> None:
+    """Encoder raises ``TypeError`` -> ``ValidationError`` on bad input."""
+    with pytest.raises(dx.ValidationError) as exc:
+        _Cfg(data_dir=42)  # type: ignore[arg-type]
+    assert exc.value.entries[0].loc == ("data_dir",)
+    assert exc.value.entries[0].type == "type_error"
+
+
+def test_purepath_base_classifies() -> None:
+    """The base ``PurePath`` (not just subclasses) classifies."""
+
+    class M(dx.Model):
+        p: PurePath
+
+    m = M(p=PurePath("a/b"))
+    assert m.p == PurePath("a/b")

--- a/packages/didactic/tests/test_tagged_union_recursive.py
+++ b/packages/didactic/tests/test_tagged_union_recursive.py
@@ -1,0 +1,116 @@
+"""Recursive / mutually-recursive TaggedUnion fields.
+
+Pins two fixes:
+
+- JSON round-trip dispatches dict payloads through the discriminator
+  so nested TaggedUnion-typed fields reconstitute correctly when
+  ``model_validate_json`` walks a payload that carries the union as
+  a dict (no envelope, just the variant's natural shape with the
+  discriminator key).
+- The variant registry is consulted *live* from ``cls.__variants__``
+  at encode/decode time, not snapshotted at field-classify time. This
+  means variants registered after a field's parent class is defined
+  (the canonical case is mutually recursive AST nodes) participate
+  fully.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+import didactic.api as dx
+
+
+class _N(dx.TaggedUnion, discriminator="kind"):
+    pass
+
+
+class _Lit(_N):
+    kind: Literal["lit"]
+    value: int
+
+
+class _BinOp(_N):
+    """Defined before ``_ListLit``; carries ``_N``-typed children.
+
+    Pins the late-registration fix: ``_BinOp`` was classified when
+    ``_N.__variants__`` only contained ``_Lit`` and ``_BinOp``, but
+    ``_ListLit`` (registered later) must still be a legal child.
+    """
+
+    kind: Literal["binop"]
+    op: str
+    left: _N
+    right: _N
+
+
+class _ListLit(_N):
+    kind: Literal["list_lit"]
+    elements: tuple[int, ...] = ()
+
+
+def test_json_round_trip_through_nested_union_field() -> None:
+    """``model_validate_json`` reconstructs nested variants correctly."""
+    node = _BinOp(
+        kind="binop",
+        op="+",
+        left=_Lit(kind="lit", value=1),
+        right=_Lit(kind="lit", value=2),
+    )
+    payload = node.model_dump_json()
+    out = _N.model_validate_json(payload)
+    assert isinstance(out, _BinOp)
+    assert out.left == _Lit(kind="lit", value=1)
+    assert out.right == _Lit(kind="lit", value=2)
+
+
+def test_late_registered_variant_is_legal_child() -> None:
+    """``_ListLit`` (defined after ``_BinOp``) can sit inside ``_BinOp.left``."""
+    node = _BinOp(
+        kind="binop",
+        op="+",
+        left=_Lit(kind="lit", value=1),
+        right=_ListLit(kind="list_lit"),
+    )
+    assert isinstance(node.right, _ListLit)
+
+
+def test_late_registered_variant_round_trips_json() -> None:
+    node = _BinOp(
+        kind="binop",
+        op="+",
+        left=_ListLit(kind="list_lit", elements=(1, 2, 3)),
+        right=_Lit(kind="lit", value=0),
+    )
+    out = _N.model_validate_json(node.model_dump_json())
+    assert isinstance(out, _BinOp)
+    assert isinstance(out.left, _ListLit)
+    assert out.left.elements == (1, 2, 3)
+
+
+def test_unknown_variant_in_dict_payload_still_rejects() -> None:
+    """The dict-dispatch relaxation only matches *registered* discriminator values."""
+    with pytest.raises(dx.ValidationError):
+        _N.model_validate_json(
+            '{"kind": "binop", "op": "+", '
+            '"left": {"kind": "missing", "value": 1}, '
+            '"right": {"kind": "lit", "value": 2}}'
+        )
+
+
+def test_dict_payload_for_directly_constructed_field() -> None:
+    """Construction with a dict child also dispatches via the discriminator.
+
+    The same encoder branch handles both the JSON round-trip path and
+    direct ``BinOp(left={"kind": "lit", "value": 1})`` callers.
+    """
+    node = _BinOp(
+        kind="binop",
+        op="+",
+        left={"kind": "lit", "value": 1},  # type: ignore[arg-type]
+        right=_Lit(kind="lit", value=2),
+    )
+    assert isinstance(node.left, _Lit)
+    assert node.left.value == 1

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Closes #21, #22, #23, #24 in one bundled v0.5.0:

- **#21**: `pathlib.Path` (and the `PurePath` family) is a first-class scalar field type.
- **#23**: `enum.StrEnum`, `enum.IntEnum`, and uniform-value-typed `enum.Enum` are first-class scalars; mixed-value enums raise `TypeNotSupportedError`.
- **#22**: TaggedUnion-typed fields JSON-round-trip when the variant is itself a TaggedUnion (the encoder dispatches dict payloads through the discriminator).
- **#24**: TaggedUnion field encoders consult `cls.__variants__` *live* instead of snapshotting at field-classify time, so mutually recursive AST shapes work in either declaration order.

## Motivation

All four were filed against didactic 0.4.3 by the same `bead` migration. #21 and #23 unblock conversion of `bead/config/*` (PathsConfig, LoggingConfig.file, DistributionStrategyType StrEnum, etc.) without forcing every Path field to be wrapped in a property. #22 and #24 unblock `bead/dsl/ast.py`'s discriminated union (mutually recursive Literal / Variable / BinaryOp / FunctionCall / ListLiteral nodes) which currently requires either declaring every variant before any composite or accepting that recursive shapes can't JSON round-trip.

## Changes

- `packages/didactic/src/didactic/types/_types.py`
  - `_is_scalar` / `_scalar_translation` extended to dispatch through `_path_translation` for `PurePath` subclasses and `_enum_translation` for str/int-valued `Enum` subclasses.
  - `_path_translation` -> sort `"Path"`, encode `str(p)`, decode `typ(s)`.
  - `_enum_kind` classifies an `Enum` subclass as `"str"` / `"int"` / `None` (rejects bool-valued and mixed-value).
  - `_enum_translation` accepts either a member or its raw value on encode (matches Pydantic; keeps `model_validate({"color": "red"})` consistent with `Color(...)` construction).
  - `_tagged_union_translation` reads `cls.__variants__` live via a new `current_variants()` closure on every encode/decode; class-creation-time snapshot is kept only for the auxiliary Theory shape.
  - `encode_one` accepts a dict carrying the discriminator and dispatches it through the live registry, fixing #22 (recursive JSON round-trip) and the dict-shaped construction path.

- `packages/didactic/src/didactic/models/_model.py`
  - `_to_json_safe` walks `PurePath` -> `str(p)` and `Enum` -> `e.value` so `model_dump` produces JSON-friendly shapes for the new field types.
  - Adds `enum` and `pathlib.PurePath` to the imports.

- `packages/didactic/tests/`
  - `test_path_field.py` (new, 6 tests)
  - `test_enum_field.py` (new, 5 tests)
  - `test_tagged_union_recursive.py` (new, 5 tests)

- `docs/guide/types.md` -- new "Paths and enums" section; the table previously listed Path/Enum aspirationally without runtime support.
- `docs/guide/unions.md` -- new "Recursive and mutually recursive variants" section.

- `CHANGELOG.md` -- `[0.5.0] - 2026-05-05` entry.
- All four packages bumped to 0.5.0.

## Tests

556 tests pass (16 new, all in the three new test modules). Coverage:

- Path: construction, JSON round-trip, PurePosixPath/PureWindowsPath subclass preservation, base PurePath, type rejection.
- Enum: StrEnum + IntEnum + value-typed plain Enum, unknown member rejection, mixed-value rejection at class creation, raw-value construction.
- TaggedUnion: recursive `BinOp(Lit, Lit)` JSON round-trip, late-registered variant as legal child, late-registered round-trip, unknown discriminator in nested dict still rejects, dict-payload field on direct construction.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (556 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible addition** -- new public field-type surface (Path, Enum) and bug fixes (TaggedUnion JSON round-trip + live registry). No previously-working code breaks. The version bump to 0.5.0 reflects the new field-type surface, not a breaking change. The dict-dispatch behaviour on TaggedUnion encoders is additive: instances are still accepted exactly as before.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.5.0]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #21.
Closes #22.
Closes #23.
Closes #24.