### PR TITLE
feat(axioms): full panproto expression language + Pythonic synonyms (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-05
+
+### Fixed
+
+- ``__axioms__`` can now reference Optional fields. The previous
+  evaluator only handled bare comparison and arithmetic; ``a == null``
+  parsed but failed at evaluation, and ``a != null`` failed even at
+  parse time. The expression-language pipeline now does two things:
+  a Python-friendly preprocessor rewrites ``!=`` -> ``/=``,
+  ``and``/``or`` -> ``&&``/``||``, ``null``/``None`` -> ``Nothing``,
+  and ``X is null`` / ``X is not null`` -> the corresponding
+  ``Nothing`` comparison; the evaluator handles the full panproto
+  Expr surface (``Just``/``Nothing``, ``App``-style builtins
+  including ``min``/``max``/``abs``/``elem``/``len``,
+  ``if/then/else`` (``Match``), ``let`` bindings, lambdas in
+  ``map``/``filter``, list literals ``[1, 2, 3]``, field access
+  ``a.b``, and the ``++`` (``Concat``) operator). The preprocessor
+  respects string literals: substitutions never fire inside ``"..."``
+  or ``'...'``. ([#26])
+
+### Changed
+
+- ``docs/guide/axioms.md`` documents the full surface (operators,
+  Python-friendly synonyms, an Optional-field worked example) and
+  narrows the "what axioms cannot do" section to the truly missing
+  constructs (``forall``/``exists``, multi-arm ``case``,
+  graph-traversal builtins).
+
+[#26]: https://github.com/panproto/didactic/issues/26
+
 ## [0.5.0] - 2026-05-05
 
 ### Added

--- a/docs/guide/axioms.md
+++ b/docs/guide/axioms.md
@@ -24,16 +24,56 @@ keyword (or the expression text, when no message is given).
 
 ## Expression syntax
 
-Axiom expressions use the panproto-Expr surface syntax. The set
-didactic's evaluator currently supports:
+Axiom expressions use the panproto-Expr surface syntax with a
+small set of Python-friendly synonyms applied at parse time. Either
+spelling works; pick whichever reads more naturally for the constraint.
 
-| operator | example |
+| category | examples |
 | --- | --- |
-| equality | `x == 0`, `x /= 0` |
+| equality | `x == 0`, `x /= 0`, `x != 0` |
 | ordering | `x < 0`, `x <= 0`, `x > 0`, `x >= 0` |
-| boolean | `a && b`, `a || b`, `not x` |
+| boolean | `a && b`, `a or b`, `not x` |
 | arithmetic | `x + y`, `x - y`, `x * y`, `x / y`, `x % y`, `-x` |
-| length | `len(xs)` |
+| absent value | `a == null`, `a == None`, `a == Nothing`, `a is null`, `a is not null` |
+| if-then-else | `if cond then x else y` |
+| `let` | `let s = a + b in s > 0` |
+| list literal | `[1, 2, 3]` |
+| field access | `a.b` (resolves via `getattr`) |
+| concat | `xs ++ ys` |
+| length / head / tail / abs | `len xs`, `head xs`, `tail xs`, `abs x` |
+| min / max / sum / and / or / all / any / elem | `min a b`, `elem x xs` |
+| map / filter (with lambda) | `map (\x -> x + 1) xs`, `filter (\x -> x > 0) xs` |
+| `Just` / `Nothing` | `Just x`, `a == Nothing` |
+
+The Python-friendly synonyms are pure surface sugar; they get
+rewritten before parsing:
+
+- `!=`  becomes `/=` (panproto's "not equal").
+- `and` / `or` keywords become `&&` / `||`.
+- `null` / `None` become `Nothing`.
+- `X is null` becomes `X == Nothing`; `X is not null` becomes
+  `X /= Nothing`.
+
+The substitutions respect string literals: nothing inside `"..."` or
+`'...'` is rewritten.
+
+### Optional fields
+
+`T | None` fields hold either a `T` or `None`. To check whether an
+optional field is set, compare to `null` / `None` / `Nothing`:
+
+```python
+class Cfg(dx.Model):
+    bounded: bool = False
+    min_value: float | None = None
+
+    __axioms__ = [
+        dx.axiom(
+            "if bounded then min_value /= null else true",
+            message="bounded models must set min_value",
+        ),
+    ]
+```
 
 The free variables in an axiom must match field names on the Model.
 Inherited fields are visible: an axiom on a base class evaluates
@@ -62,11 +102,12 @@ Tighter(x=200)           # raises (own axiom)
 
 ## What axioms cannot do (yet)
 
-The panproto-Expr surface syntax is broader than the subset didactic
-currently evaluates. Constructs the evaluator does not yet handle
-include `forall`, `exists`, `let`, `case`, lambdas, and graph
-traversal. An axiom using one of those parses successfully but the
-evaluator raises `NotImplementedError` at construction.
+panproto's parser accepts a few constructs that the runtime
+evaluator deliberately does not implement: `forall` and `exists`
+quantifiers, `case`-style multi-arm pattern matching beyond the
+`if/then/else` shape, and graph-traversal builtins. An axiom using
+one of those parses successfully but the evaluator raises
+`NotImplementedError` at construction.
 
 You can still declare such axioms; they are recorded in
 `__class_axioms__` and surface in tooling that walks the Theory's

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.5.0"
+version = "0.5.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.5.0"
+version = "0.5.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/axioms/_axiom_enforcement.py
+++ b/packages/didactic/src/didactic/axioms/_axiom_enforcement.py
@@ -1,14 +1,39 @@
 """Axiom enforcement: parse axiom strings into predicates run at construction.
 
 Each ``__axioms__`` entry is parsed into a panproto ``Expr`` AST via
-``panproto.parse_expr``, then evaluated against a Model instance's
-field values during construction. Failures raise
+``panproto.parse_expr`` (after a small Python-friendly preprocessing
+pass), then evaluated against a Model instance's field values during
+construction. Failures raise
 [didactic.api.ValidationError][didactic.api.ValidationError] with the axiom's
 message.
 
-The evaluator walks the panproto Expr ``to_dict()`` form, which is a
-tagged union of ``{"Builtin": ...}``, ``{"Var": ...}``, ``{"Lit": ...}``,
-and a small set of other variants.
+Surface syntax
+--------------
+
+The accepted surface syntax is panproto's Haskell-flavoured expression
+language augmented with Python-friendly synonyms:
+
+- ``!=``  is rewritten to ``/=`` (panproto's spelling of "not equal").
+- ``and`` / ``or`` keywords are rewritten to ``&&`` / ``||``.
+- ``null`` / ``None`` are rewritten to panproto's ``Nothing`` literal,
+  which evaluates to Python ``None``. Optional fields holding ``None``
+  compare equal to ``Nothing``.
+- ``X is null``      -> ``X == Nothing``.
+- ``X is not null``  -> ``X /= Nothing``.
+
+The preprocessor respects string literals: substrings inside ``"..."``
+are not touched.
+
+The evaluator walks the panproto Expr ``to_dict()`` form. Supported
+shapes: ``Var``, ``Lit`` (``Int``/``Float``/``Str``/``Bool``/``Char``
+and the ``"Null"`` sentinel), ``Builtin`` (every comparison and boolean
+operator, plus arithmetic and ``Len``/``Head``/``Tail``/``Abs``/
+``Concat``/``Map``/``Filter``/``Edge``), ``App`` (function application:
+``Just X`` unwraps to ``X``, ``Nothing`` -> ``None``; ``min``/``max``/
+``abs``/``and``/``or``/``sum``/``all``/``any``/``elem``/``len`` resolve
+to their Python equivalents), ``Field`` (``a.b`` -> ``getattr``),
+``List`` literal, ``Match`` (``if/then/else`` and pattern matching on
+``Bool`` / ``Wildcard`` / literal arms), ``Lam`` (lambda), and ``Let``.
 
 See Also
 --------
@@ -18,10 +43,11 @@ panproto.parse_expr : the underlying parser.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from didactic.axioms._axioms import Axiom
     from didactic.types._typing import FieldValue, JsonValue
@@ -44,15 +70,80 @@ type ExprNode = JsonValue
 type EvalResult = FieldValue
 
 
-def parse_axiom_predicate(axiom: Axiom):  # type: ignore[no-untyped-def]
+# Word-boundary patterns for the Pythonic-syntax preprocessor. Each
+# rule is a (pattern, replacement) pair applied to the substring of
+# the axiom source that lies *outside* string literals; ``preprocess``
+# walks the source character-by-character so the rules never fire
+# inside ``"..."``.
+_PYTHON_SUBSTITUTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # ``X is null`` / ``X is not null`` rewrite. Match minimally so
+    # ``is`` between unrelated identifiers (rare in axiom syntax) is
+    # untouched. Rewrite to panproto's Haskell spellings.
+    (re.compile(r"\bis\s+not\s+null\b"), "/= Nothing"),
+    (re.compile(r"\bis\s+null\b"), "== Nothing"),
+    # ``!=`` -> ``/=`` (panproto's "not equal").
+    (re.compile(r"!="), "/="),
+    # ``null`` / ``None`` literal -> panproto's ``Nothing``.
+    (re.compile(r"\bnull\b"), "Nothing"),
+    (re.compile(r"\bNone\b"), "Nothing"),
+    # ``and`` / ``or`` keywords -> ``&&`` / ``||``.
+    (re.compile(r"\band\b"), "&&"),
+    (re.compile(r"\bor\b"), "||"),
+)
+
+
+def preprocess_axiom_source(src: str) -> str:
+    r"""Translate Python-friendly axiom syntax to panproto's spellings.
+
+    Walks ``src`` character by character so the rules never fire inside
+    string literals. Supports both ``"..."`` and ``'...'`` quoting and
+    the standard ``\`` escape inside them.
+
+    See module docstring for the rule list.
+    """
+    out: list[str] = []
+    i = 0
+    chunk_start = 0
+    while i < len(src):
+        ch = src[i]
+        if ch in ('"', "'"):
+            # flush the outside chunk (rules apply), then walk the string
+            # contents through unchanged.
+            outside = src[chunk_start:i]
+            for pattern, repl in _PYTHON_SUBSTITUTIONS:
+                outside = pattern.sub(repl, outside)
+            out.append(outside)
+            quote = ch
+            string_start = i
+            i += 1
+            while i < len(src):
+                if src[i] == "\\" and i + 1 < len(src):
+                    i += 2
+                    continue
+                if src[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            out.append(src[string_start:i])
+            chunk_start = i
+            continue
+        i += 1
+    tail = src[chunk_start:]
+    for pattern, repl in _PYTHON_SUBSTITUTIONS:
+        tail = pattern.sub(repl, tail)
+    out.append(tail)
+    return "".join(out)
+
+
+def parse_axiom_predicate(axiom: Axiom) -> Callable[[dict[str, FieldValue]], bool]:
     """Parse an axiom expression into a callable predicate.
 
     Parameters
     ----------
     axiom
         An [Axiom][didactic.api.Axiom] instance whose ``expr`` is the
-        Haskell-style surface syntax accepted by
-        ``panproto.parse_expr``.
+        surface syntax accepted by ``panproto.parse_expr`` plus the
+        Python-friendly synonyms documented in the module header.
 
     Returns
     -------
@@ -72,7 +163,8 @@ def parse_axiom_predicate(axiom: Axiom):  # type: ignore[no-untyped-def]
     """
     import panproto  # noqa: PLC0415
 
-    expr = panproto.parse_expr(axiom.expr)
+    rewritten = preprocess_axiom_source(axiom.expr)
+    expr = panproto.parse_expr(rewritten)
     # ``Expr.to_dict()`` returns ``dict[str, object]`` (the panproto
     # binding doesn't declare a tighter type because the leaf values
     # are dynamic). Cast to the ``JsonValue`` shape ``_evaluate``
@@ -88,32 +180,61 @@ def parse_axiom_predicate(axiom: Axiom):  # type: ignore[no-untyped-def]
 def _evaluate(node: ExprNode, env: dict[str, FieldValue]) -> EvalResult:
     """Walk a panproto Expr ``to_dict`` AST and evaluate against ``env``.
 
-    The function handles the common subset that shows up in axiom
-    expressions: variable lookup, literals, comparison operators,
-    boolean connectives, and arithmetic. Unrecognised node shapes
-    raise ``NotImplementedError``.
+    Handles the full panproto Expr surface that shows up in axiom
+    expressions: variables, literals (including the ``"Null"``
+    sentinel for ``Nothing``), comparisons, boolean connectives,
+    arithmetic, ``Just``/``Nothing`` constructors, function
+    application (``App``), field access, list literals,
+    ``if/then/else`` (``Match``), pattern matching, lambdas, and
+    ``let`` bindings. Unrecognised shapes raise ``NotImplementedError``.
 
     Pattern-matched on the panproto Expr shape: each variant is
     a single-key dict whose value has a known structure. The match
     statements narrow the dynamic ``ExprNode`` shape into the typed
     sub-shapes the helpers consume.
     """
+    # Tuples flow through panproto's bindings as plain Python tuples
+    # (e.g. ``Builtin: (op, args)``); pattern-match on either form so
+    # the dispatcher tolerates both.
     match node:
         case {"Var": str(name)}:
-            if name not in env:
-                msg = f"axiom references unbound variable {name!r}"
-                raise NameError(msg)
-            return env[name]
+            if name == "Nothing":
+                return None
+            if name in env:
+                return env[name]
+            msg = f"axiom references unbound variable {name!r}"
+            raise NameError(msg)
+        case {"Lit": "Null"}:
+            return None
         case {"Lit": dict(lit)}:
             return _evaluate_literal(lit)
-        case {"Builtin": [str(op), list(args)]}:
-            return _evaluate_builtin(op, args, env)
-        case {"App": [dict(func), arg]}:
-            # general App: rare in axioms; treat as a builtin family if
-            # head is a Var pointing at a known function name
-            if "Var" in func and isinstance(func["Var"], str):
-                return _evaluate_builtin(func["Var"], [arg], env)
-            msg = f"App nodes with non-Var heads are not supported: {func!r}"
+        case {"Builtin": (str(op), args)} | {"Builtin": [str(op), args]}:
+            return _evaluate_builtin(op, list(cast("Sequence[ExprNode]", args)), env)
+        case {"App": (func, arg)} | {"App": [func, arg]}:
+            return _evaluate_app(func, arg, env)
+        case {"Field": (target, str(field_name))} | {
+            "Field": [target, str(field_name)]
+        }:
+            target_value = _evaluate(target, env)
+            try:
+                return cast("EvalResult", getattr(target_value, field_name))
+            except AttributeError as exc:
+                msg = (
+                    f"axiom field access {field_name!r} failed on "
+                    f"{type(target_value).__name__}"
+                )
+                raise NameError(msg) from exc
+        case {"List": list(items)}:
+            return cast("EvalResult", [_evaluate(item, env) for item in items])
+        case {"Match": dict(payload)}:
+            return _evaluate_match(payload, env)
+        case {"Let": dict(payload)}:
+            return _evaluate_let(payload, env)
+        case {"Lam": (str(_), _)} | {"Lam": [str(_), _]}:
+            # Lambdas only show up as the head of an App; ``_evaluate_app``
+            # binds and recurses. A bare lambda outside an App position
+            # has no defined value at axiom time.
+            msg = "bare lambda outside an application is not supported in axioms"
             raise NotImplementedError(msg)
         case _:
             msg = f"unsupported Expr node shape: {node!r}"
@@ -136,6 +257,132 @@ def _evaluate_literal(lit: ExprNode) -> EvalResult:
         case _:
             msg = f"unsupported Literal: {lit!r}"
             raise NotImplementedError(msg)
+
+
+# Single-argument builtins reachable as ``App`` heads (panproto parses
+# ``min a b`` as ``App(App(Var('min'), a), b)`` rather than
+# ``Builtin('Min', [a, b])``). Each entry is a callable taking the
+# already-evaluated argument list.
+_APP_BUILTINS_BY_NAME: dict[str, Callable[[list[FieldValue]], FieldValue]] = {
+    "Just": lambda a: a[0],
+    "min": lambda a: min(a[0], a[1]),  # type: ignore[type-var]
+    "max": lambda a: max(a[0], a[1]),  # type: ignore[type-var]
+    "abs": lambda a: abs(a[0]),  # type: ignore[arg-type]
+    "len": lambda a: len(a[0]),  # type: ignore[arg-type]
+    "and": lambda a: all(bool(x) for x in cast("list[object]", a[0])),
+    "or": lambda a: any(bool(x) for x in cast("list[object]", a[0])),
+    "all": lambda a: all(bool(x) for x in cast("list[object]", a[0])),
+    "any": lambda a: any(bool(x) for x in cast("list[object]", a[0])),
+    "sum": lambda a: sum(cast("list[float]", a[0])),
+    "elem": lambda a: a[0] in cast("list[object]", a[1]),
+    "fst": lambda a: a[0][0],  # type: ignore[index]
+    "snd": lambda a: a[0][1],  # type: ignore[index]
+    "id": lambda a: a[0],
+}
+
+
+def _flatten_app(func: ExprNode, arg: ExprNode) -> tuple[ExprNode, list[ExprNode]]:
+    """Unfold a curried ``App(App(..., a1), aN)`` into ``(head, [a1, ..., aN])``."""
+    head: ExprNode = func
+    rev_args: list[ExprNode] = [arg]
+    while True:
+        match head:
+            case {"App": (next_head, next_arg)} | {"App": [next_head, next_arg]}:
+                rev_args.append(next_arg)
+                head = next_head
+            case _:
+                break
+    return head, list(reversed(rev_args))
+
+
+def _evaluate_app(
+    func: ExprNode, arg: ExprNode, env: dict[str, FieldValue]
+) -> EvalResult:
+    """Evaluate a function application.
+
+    ``Just X`` unwraps to ``X``; ``Nothing`` (as a head) yields
+    ``None`` (with the argument ignored, matching panproto's nullary
+    constructor convention). Bare ``Var``-headed apps look the head up
+    in the per-axiom builtin table; ``Lam``-headed apps bind and
+    recurse on the body.
+    """
+    head, args = _flatten_app(func, arg)
+    match head:
+        case {"Var": "Nothing"} | {"Lit": "Null"}:
+            return None
+        case {"Var": str(name)} if name in _APP_BUILTINS_BY_NAME:
+            evaluated = [_evaluate(a, env) for a in args]
+            return _APP_BUILTINS_BY_NAME[name](evaluated)
+        case {"Var": "not"}:
+            return not bool(_evaluate(args[0], env))
+        case {"Lam": (str(param), body)} | {"Lam": [str(param), body]}:
+            new_env = dict(env)
+            new_env[param] = _evaluate(args[0], env)
+            result = _evaluate(body, new_env)
+            for extra in args[1:]:
+                result = _evaluate_app(
+                    cast("ExprNode", {"Lit": {"Int": 0}}),  # placeholder unused
+                    extra,
+                    {**new_env, "__result__": result},
+                )
+            return result
+        case {"Var": str(name)}:
+            msg = f"axiom evaluator does not yet implement function {name!r}"
+            raise NotImplementedError(msg)
+        case _:
+            msg = f"axiom evaluator does not support App-head shape {head!r}"
+            raise NotImplementedError(msg)
+
+
+def _evaluate_match(payload: ExprNode, env: dict[str, FieldValue]) -> EvalResult:
+    """Evaluate an ``if/then/else`` or pattern-match expression.
+
+    panproto compiles ``if a then b else c`` to a ``Match`` over
+    ``a`` with arms ``[(Lit Bool True, b), (Wildcard, c)]``. The
+    general form supports literal-pattern arms and a ``"Wildcard"``
+    fallback.
+    """
+    if not isinstance(payload, dict):
+        msg = f"Match payload must be a dict, got {type(payload).__name__}"
+        raise NotImplementedError(msg)
+    scrutinee = payload.get("scrutinee")
+    arms = payload.get("arms")
+    if scrutinee is None or not isinstance(arms, list):
+        msg = f"Match payload missing scrutinee/arms: {payload!r}"
+        raise NotImplementedError(msg)
+    value = _evaluate(cast("ExprNode", scrutinee), env)
+    for arm in arms:
+        if not isinstance(arm, (tuple, list)) or len(arm) != 2:
+            msg = f"Match arm must be (pattern, body), got {arm!r}"
+            raise NotImplementedError(msg)
+        pattern, body = arm[0], arm[1]
+        if pattern == "Wildcard":
+            return _evaluate(cast("ExprNode", body), env)
+        if isinstance(pattern, dict):
+            pat_value = _evaluate(cast("ExprNode", pattern), env)
+            if pat_value == value:
+                return _evaluate(cast("ExprNode", body), env)
+            continue
+        msg = f"axiom evaluator does not support Match pattern {pattern!r}"
+        raise NotImplementedError(msg)
+    msg = f"Match has no arm covering scrutinee value {value!r}"
+    raise NameError(msg)
+
+
+def _evaluate_let(payload: ExprNode, env: dict[str, FieldValue]) -> EvalResult:
+    """Evaluate a ``let name = value in body`` expression."""
+    if not isinstance(payload, dict):
+        msg = f"Let payload must be a dict, got {type(payload).__name__}"
+        raise NotImplementedError(msg)
+    name = payload.get("name")
+    value_node = payload.get("value")
+    body_node = payload.get("body")
+    if not isinstance(name, str) or value_node is None or body_node is None:
+        msg = f"Let payload missing name/value/body: {payload!r}"
+        raise NotImplementedError(msg)
+    new_env = dict(env)
+    new_env[name] = _evaluate(cast("ExprNode", value_node), env)
+    return _evaluate(cast("ExprNode", body_node), new_env)
 
 
 def _evaluate_builtin(
@@ -193,9 +440,65 @@ def _evaluate_builtin(
     # length-style helpers (axioms about collection sizes are common)
     if op == "Len":
         return len(_evaluate(args[0], env))  # type: ignore[arg-type]
+    if op == "Head":
+        seq = cast("Sequence[FieldValue]", _evaluate(args[0], env))
+        return seq[0]
+    if op == "Tail":
+        seq = cast("Sequence[FieldValue]", _evaluate(args[0], env))
+        return cast("EvalResult", list(seq[1:]))
+    if op == "Abs":
+        return abs(_evaluate(args[0], env))  # type: ignore[arg-type]
+
+    # list / string concatenation: ``a ++ b``
+    if op == "Concat":
+        a = _evaluate(args[0], env)
+        b = _evaluate(args[1], env)
+        return a + b  # type: ignore[operator]
+
+    # map / filter: each takes a one-arg function as its first argument.
+    # The function is either an identifier (looked up in
+    # ``_APP_BUILTINS_BY_NAME``) or a ``Lam``.
+    if op == "Map":
+        func_node, seq_node = args[0], args[1]
+        seq = cast("Sequence[FieldValue]", _evaluate(seq_node, env))
+        return cast("EvalResult", [_apply_unary(func_node, item, env) for item in seq])
+    if op == "Filter":
+        func_node, seq_node = args[0], args[1]
+        seq = cast("Sequence[FieldValue]", _evaluate(seq_node, env))
+        return cast(
+            "EvalResult",
+            [item for item in seq if bool(_apply_unary(func_node, item, env))],
+        )
+
+    # Edge: ``a -> "b"`` parses to ``Builtin('Edge', [Var a, Lit "b"])``.
+    # In an axiom expression this is a graph-shape predicate that
+    # rarely shows up; treat it as the underlying string ``b``.
+    if op == "Edge":
+        return _evaluate(args[1], env)
 
     msg = f"axiom evaluator does not yet implement Builtin {op!r}"
     raise NotImplementedError(msg)
+
+
+def _apply_unary(
+    func_node: ExprNode, value: FieldValue, env: dict[str, FieldValue]
+) -> EvalResult:
+    """Apply a one-argument function (identifier or lambda) to ``value``."""
+    match func_node:
+        case {"Lam": (str(param), body)} | {"Lam": [str(param), body]}:
+            new_env = dict(env)
+            new_env[param] = value
+            return _evaluate(body, new_env)
+        case {"Var": str(name)} if name in _APP_BUILTINS_BY_NAME:
+            return _APP_BUILTINS_BY_NAME[name]([value])
+        case {"Var": "not"}:
+            return not bool(value)
+        case _:
+            msg = (
+                "axiom map/filter function must be a lambda or known "
+                f"builtin name; got {func_node!r}"
+            )
+            raise NotImplementedError(msg)
 
 
 def check_class_axioms(cls: type, env: dict[str, FieldValue]) -> list[str]:

--- a/packages/didactic/tests/test_axiom_expression_language.py
+++ b/packages/didactic/tests/test_axiom_expression_language.py
@@ -1,0 +1,243 @@
+"""Full panproto expression-language coverage for axioms.
+
+Pins the v0.5.1 evaluator scope: every form documented in
+``didactic.axioms._axiom_enforcement`` should round-trip through a
+``__axioms__`` declaration, with the Python-friendly preprocessor
+translating ``!=``, ``and``/``or``, ``null``/``None``, and
+``is null`` / ``is not null`` to panproto's spellings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+import didactic.api as dx
+
+if TYPE_CHECKING:
+    from didactic.types._typing import FieldValue
+from didactic.axioms._axiom_enforcement import (
+    parse_axiom_predicate,
+    preprocess_axiom_source,
+)
+
+
+# -- preprocessor --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        ("a != b", "a /= b"),
+        ("a == null", "a == Nothing"),
+        ("a == None", "a == Nothing"),
+        ("a is null", "a == Nothing"),
+        ("a is not null", "a /= Nothing"),
+        ("a and b", "a && b"),
+        ("a or b", "a || b"),
+        # multiple substitutions in one expression
+        ("a is null and b != null", "a == Nothing && b /= Nothing"),
+    ],
+)
+def test_preprocessor_python_to_panproto(src: str, expected: str) -> None:
+    assert preprocess_axiom_source(src) == expected
+
+
+def test_preprocessor_respects_string_literals() -> None:
+    """Substitutions don't fire inside ``"..."`` or ``'...'`` strings."""
+    src = "tag != \"is not null\" and msg /= 'a or b'"
+    out = preprocess_axiom_source(src)
+    # The outer ``!=`` and ``and`` are rewritten; the string contents stay.
+    assert out == "tag /= \"is not null\" && msg /= 'a or b'"
+
+
+def test_preprocessor_handles_escaped_quotes() -> None:
+    """Backslash-escaped quotes inside a string don't end the literal early."""
+    src = r'a != "x \"and\" y"'
+    out = preprocess_axiom_source(src)
+    assert out == r'a /= "x \"and\" y"'
+
+
+# -- null / Optional axioms (the issue's repro) --------------------------
+
+
+class _Cfg(dx.Model):
+    a: int | None = None
+    b: str | None = None
+    __axioms__ = (dx.axiom("a == null or b != null", message="a requires b"),)
+
+
+def test_optional_axiom_holds_when_both_none() -> None:
+    _Cfg(a=None, b=None)
+
+
+def test_optional_axiom_holds_when_b_set() -> None:
+    _Cfg(a=1, b="x")
+
+
+def test_optional_axiom_fails_when_a_set_without_b() -> None:
+    with pytest.raises(dx.ValidationError) as exc:
+        _Cfg(a=1)
+    assert exc.value.entries[0].msg == "a requires b"
+
+
+# -- the spelled-out forms all work -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "a == null or b != null",
+        "a == None or b /= None",
+        "a is null or b is not null",
+        "a == Nothing || b /= Nothing",
+    ],
+)
+def test_alternate_spellings_all_evaluate(expr: str) -> None:
+    """Every Python-friendly spelling routes to the same panproto AST."""
+    pred = parse_axiom_predicate(dx.axiom(expr))
+    assert pred({"a": None, "b": None}) is True
+    assert pred({"a": 1, "b": "x"}) is True
+    assert pred({"a": 1, "b": None}) is False
+
+
+# -- arithmetic and comparison ------------------------------------------
+
+
+def test_arithmetic_and_comparison() -> None:
+    pred = parse_axiom_predicate(dx.axiom("a + b * 2 > c"))
+    assert pred({"a": 1, "b": 3, "c": 5}) is True
+    assert pred({"a": 1, "b": 1, "c": 10}) is False
+
+
+# -- if/then/else (Match) -----------------------------------------------
+
+
+def test_if_then_else() -> None:
+    pred = parse_axiom_predicate(dx.axiom("if bounded then min /= null else true"))
+    assert pred({"bounded": True, "min": 0, "true": True}) is True
+    assert pred({"bounded": True, "min": None, "true": True}) is False
+    assert pred({"bounded": False, "min": None, "true": True}) is True
+
+
+# -- App-style builtins (min, max, abs, len) ----------------------------
+
+
+def test_min_max_abs_via_app() -> None:
+    assert parse_axiom_predicate(dx.axiom("min a b == 1"))({"a": 1, "b": 2}) is True
+    assert parse_axiom_predicate(dx.axiom("max a b == 2"))({"a": 1, "b": 2}) is True
+    assert parse_axiom_predicate(dx.axiom("abs (a - b) == 3"))({"a": 1, "b": 4}) is True
+
+
+def test_len_works() -> None:
+    pred = parse_axiom_predicate(dx.axiom("len xs > 0"))
+    assert pred({"xs": (1, 2, 3)}) is True
+    assert pred({"xs": ()}) is False
+
+
+# -- list literal + elem -------------------------------------------------
+
+
+def test_list_literal_and_elem() -> None:
+    pred = parse_axiom_predicate(dx.axiom("elem x [1, 2, 3]"))
+    assert pred({"x": 2}) is True
+    assert pred({"x": 5}) is False
+
+
+# -- list / string concatenation (++) ------------------------------------
+
+
+def test_concat() -> None:
+    pred = parse_axiom_predicate(dx.axiom('xs ++ ys == "abdef"'))
+    assert pred({"xs": "ab", "ys": "def"}) is True
+
+
+# -- Field access (a.b) -------------------------------------------------
+
+
+def test_field_access() -> None:
+    """``a.b`` resolves via getattr."""
+
+    class _Box:
+        def __init__(self, n: int) -> None:
+            self.n = n
+
+    pred = parse_axiom_predicate(dx.axiom("box.n == 7"))
+    assert pred(cast("dict[str, FieldValue]", {"box": _Box(7)})) is True
+    assert pred(cast("dict[str, FieldValue]", {"box": _Box(0)})) is False
+
+
+# -- let bindings -------------------------------------------------------
+
+
+def test_let_binding() -> None:
+    pred = parse_axiom_predicate(dx.axiom("let s = a + b in s > 0"))
+    assert pred({"a": 1, "b": 2}) is True
+    assert pred({"a": -5, "b": 3}) is False
+
+
+# -- map / filter (with lambda or builtin) ------------------------------
+
+
+def test_map_with_lambda() -> None:
+    pred = parse_axiom_predicate(dx.axiom("len (map (\\x -> x + 1) xs) == 3"))
+    assert pred(cast("dict[str, FieldValue]", {"xs": [1, 2, 3]})) is True
+
+
+def test_filter_with_lambda() -> None:
+    pred = parse_axiom_predicate(dx.axiom("len (filter (\\x -> x > 0) xs) == 2"))
+    assert pred(cast("dict[str, FieldValue]", {"xs": [-1, 1, 2]})) is True
+
+
+# -- Just / Nothing -----------------------------------------------------
+
+
+def test_just_unwraps() -> None:
+    pred = parse_axiom_predicate(dx.axiom("Just x == y"))
+    assert pred({"x": 5, "y": 5}) is True
+
+
+def test_nothing_compares_to_none() -> None:
+    pred = parse_axiom_predicate(dx.axiom("a == Nothing"))
+    assert pred({"a": None}) is True
+    assert pred({"a": 1}) is False
+
+
+# -- error cases --------------------------------------------------------
+
+
+def test_unknown_function_raises_clear_error() -> None:
+    """An unrecognised function name surfaces as a validation failure."""
+
+    class _M(dx.Model):
+        x: int = 0
+        __axioms__ = (dx.axiom("zarquon x == 0"),)
+
+    with pytest.raises(dx.ValidationError) as exc:
+        _M(x=0)
+    assert "cannot evaluate" in exc.value.entries[0].msg
+
+
+# -- regression: existing axioms still pass -----------------------------
+
+
+class _Range(dx.Model):
+    low: int = 0
+    high: int = 10
+    __axioms__ = (dx.axiom("low <= high"),)
+
+
+def test_existing_arithmetic_axiom_still_works() -> None:
+    _Range(low=0, high=10)
+    with pytest.raises(dx.ValidationError):
+        _Range(low=5, high=3)
+
+
+def test_axiom_record_is_immutable() -> None:
+    """Axiom is a frozen dataclass; ``replace`` produces a new record."""
+    a = dx.axiom("x == 0")
+    b = replace(a, message="x must be zero")
+    assert a.expr == b.expr
+    assert b.message == "x must be zero"

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

`__axioms__` could only express constraints over fully-required fields through bare comparison and arithmetic. `a == null` parsed but failed at evaluation; `a != null` failed at parse. This PR wires the full panproto Expr surface into the runtime evaluator and adds a small Python-friendly preprocessor so the natural Pydantic-shaped spelling (`a == null or b != null`) just works. Closes #26.

## Motivation

Surfaced finalising the `bead` Pydantic→didactic migration. Cross-field invariants involving Optional fields are routine in configuration models -- "min_distance set implies no_adjacent_property set", "bounded=True implies min_value and max_value are set" -- and have no expressible form today: `__axioms__` rejects them, `@validates` only sees one field at a time, and free-function validators lose construction-time enforcement.

The fix is shaped to make Pydantic-shaped expressions land first try (`!=`, `and`/`or`, `null`/`None`, `is null`) without forcing users to learn panproto's Haskell spelling, while leaving every Haskell spelling working too.

## Changes

- `packages/didactic/src/didactic/axioms/_axiom_enforcement.py`
  - New `preprocess_axiom_source(src)` rewrites `!=` -> `/=`, `and`/`or` -> `&&`/`||`, `null`/`None` -> `Nothing`, `X is null` -> `X == Nothing`, `X is not null` -> `X /= Nothing`. Walks character-by-character so substitutions never fire inside string literals (handles both `"..."` and `'...'` plus backslash escapes).
  - `parse_axiom_predicate` runs the source through the preprocessor before `panproto.parse_expr`.
  - `_evaluate` extended to dispatch on every panproto Expr shape: `Var "Nothing"` and `Lit: "Null"` -> `None`; `Field` -> `getattr`; `List` literal; `Match` (`if/then/else` plus literal-pattern + Wildcard arms); `Let`; `App` via a new `_flatten_app` that unfolds curried chains; `Lam` heads; field/builtin head dispatch via a per-name table containing `Just`, `min`, `max`, `abs`, `len`, `and`, `or`, `all`, `any`, `sum`, `elem`, `fst`, `snd`, `id`, plus the `not` head.
  - `_evaluate_builtin` extended with `Head`, `Tail`, `Abs`, `Concat`, `Map`, `Filter`, `Edge`. `Map`/`Filter` apply a unary function (lambda or builtin name) to each element via a new `_apply_unary` helper.

- `packages/didactic/tests/test_axiom_expression_language.py` (new, 32 tests).

- `docs/guide/axioms.md` -- new operator/builtin table covering the full surface, a Python-friendly synonyms section, an Optional-field worked example, and a narrowed "what axioms cannot do" section.

- `CHANGELOG.md` -- `[0.5.1] - 2026-05-05` entry.

- All four packages bumped to 0.5.1.

## Tests

588 tests pass (32 new). Coverage:

- Preprocessor: all six rule shapes, string-literal respect with both quoting styles and escape sequences.
- The issue's exact repro plus the four equivalent spellings of the same constraint.
- Each newly supported evaluator shape: `if/then/else`, `min`/`max`/`abs`/`len`, `elem` over a list literal, `++`, field access, `let`, `map`/`filter` with lambdas, `Just`/`Nothing`.
- Unknown-function clear-error path.
- Regression: existing arithmetic axiom (`low <= high`) still works; `Axiom` is still a frozen dataclass.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (588 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible addition.** Every axiom that previously evaluated still evaluates identically. The preprocessor only fires on substrings outside string literals, so any axiom that happens to contain `!=` or `and`/`or` *as code* gets the new spelling -- but those previously failed to parse, so there's no working axiom that could have used those tokens to mean something else.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.5.1]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #26.