### PR TITLE
fix(types): Embed[TaggedUnion] preserves variant identity (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-05
+
+### Fixed
+
+- ``Embed[Root]`` where ``Root`` is a ``TaggedUnion`` no longer
+  downcasts variant instances to the root class. The Embed encoder
+  always wrote the variant's full storage dict (including the
+  variant-specific fields), but the decoder reconstructed the value
+  via ``Root.from_storage_dict`` -- the root has no field specs of
+  its own, so the variant fields became unreachable on the recovered
+  instance. The Embed translation now inspects the stored
+  discriminator value at decode time and dispatches to the matching
+  variant in ``Root.__variants__``, mirroring the live-registry fix
+  used elsewhere in the TaggedUnion path. ``tuple[Embed[Root], ...]``,
+  ``dict[str, Embed[Root]]``, and bare ``Embed[Root]`` fields all
+  preserve the variant subclass identity through construction,
+  storage round-trip, and JSON round-trip. Plain ``Embed[T]`` (no
+  TaggedUnion) keeps the legacy single-class path unchanged. ([#27])
+
+[#27]: https://github.com/panproto/didactic/issues/27
+
 ## [0.5.1] - 2026-05-05
 
 ### Fixed

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.5.1"
+version = "0.5.2"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.5.1"
+version = "0.5.2"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.5.1"
+version = "0.5.2"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.5.1"
+version = "0.5.2"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -68,7 +68,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -1919,6 +1919,13 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
     by reconstructing a ``T`` via its private ``from_storage_dict`` hook
     (no validation re-runs because the storage is already in encoded form).
 
+    When ``T`` is a [didactic.api.TaggedUnion][didactic.api.TaggedUnion] root,
+    the encoder preserves the variant subclass identity (the input is a
+    variant instance with its own field set), and the decoder dispatches
+    on the stored discriminator value to reconstruct the same variant
+    subclass instead of the bare root. Without this, every variant's
+    extra fields would be invisible after a round-trip through Embed.
+
     Parameters
     ----------
     base
@@ -1935,6 +1942,7 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
     must be resolved by classification time.
     """
     from didactic.fields._refs import EmbedSentinel  # noqa: PLC0415
+    from didactic.fields._unions import TaggedUnion  # noqa: PLC0415
     from didactic.models._model import Model  # noqa: PLC0415
 
     assert any(isinstance(m, EmbedSentinel) for m in metadata)
@@ -1947,12 +1955,46 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
 
     target_cls: type[Model] = base
     target_name = target_cls.__name__
+    is_union_root = (
+        issubclass(target_cls, TaggedUnion)
+        and target_cls is not TaggedUnion
+        and getattr(target_cls, "__discriminator__", None) is not None
+    )
+    discriminator: str | None = (
+        cast("str", target_cls.__discriminator__)  # type: ignore[attr-defined]
+        if is_union_root
+        else None
+    )
+
+    def _resolve_variant(items: dict[str, JsonValue]) -> type[Model]:
+        """Pick the variant subclass for a stored Embed[Root] payload.
+
+        The discriminator field is a ``Literal[...]`` of string values
+        (the only shape ``TaggedUnion`` accepts), and the panproto
+        String encoder is the identity, so the stored discriminator
+        value sits in ``items`` as the raw string. Look it up in the
+        live variant registry; fall back to ``target_cls`` if the
+        discriminator key is absent (the legacy single-class Embed
+        path) or holds an unregistered value (a stale storage from a
+        schema older than the current variant registry).
+        """
+        if not is_union_root or discriminator is None:
+            return target_cls
+        disc_value = items.get(discriminator)
+        if disc_value is None:
+            return target_cls
+        variants = cast(
+            "dict[object, type[Model]]",
+            target_cls.__variants__,  # type: ignore[attr-defined]
+        )
+        return variants.get(disc_value, target_cls)
 
     def encode(v: FieldValue) -> Encoded:
-        # accept either a target_cls instance or a dict. The dict path
-        # goes through ``model_validate_json`` (not ``model_validate``)
-        # so each per-field ``from_json`` runs and JSON-shape values
-        # like ``[1, 2, 3]`` for a ``tuple[int, ...]`` field get the
+        # accept either a target_cls instance (or, for TaggedUnion roots,
+        # any registered variant instance) or a dict. The dict path goes
+        # through ``model_validate_json`` (not ``model_validate``) so each
+        # per-field ``from_json`` runs and JSON-shape values like
+        # ``[1, 2, 3]`` for a ``tuple[int, ...]`` field get the
         # list-to-tuple coercion before the field encoder asserts.
         if isinstance(v, target_cls):
             return json.dumps(v.to_storage_dict())
@@ -1974,7 +2016,9 @@ def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTran
                 f"got {type(items).__name__}"
             )
             raise TypeError(msg)
-        return target_cls.from_storage_dict(cast("dict[str, str]", items))
+        items_dict = cast("dict[str, JsonValue]", items)
+        variant_cls = _resolve_variant(items_dict)
+        return variant_cls.from_storage_dict(cast("dict[str, str]", items_dict))
 
     def from_json(v: JsonValue) -> FieldValue:
         # the JSON form is the model_dump dict (decoded values), not

--- a/packages/didactic/tests/test_embed_tagged_union.py
+++ b/packages/didactic/tests/test_embed_tagged_union.py
@@ -1,0 +1,166 @@
+"""``Embed[Root]`` preserves variant subclass identity.
+
+Before the v0.5.2 fix, embedding a TaggedUnion variant inside another
+Model's field stored the variant's storage dict but reconstructed it
+as the bare root class (which has no field specs of its own). Every
+variant-specific field was invisible after a round-trip through the
+Embed boundary. The fix dispatches at decode time on the stored
+discriminator value.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+import didactic.api as dx
+
+
+class _Node(dx.TaggedUnion, discriminator="kind"):
+    pass
+
+
+class _Lit(_Node):
+    kind: Literal["lit"]
+    value: int
+
+
+class _Var(_Node):
+    kind: Literal["var"]
+    name: str
+
+
+class _Container(dx.Model):
+    items: tuple[dx.Embed[_Node], ...] = ()
+    head: dx.Embed[_Node] | None = None
+
+
+class _Inner(dx.Model):
+    x: int
+
+
+class _Outer(dx.Model):
+    inner: dx.Embed[_Inner]
+
+
+# Variant declared late (after Container's Embed-typed field was classified)
+# to pin the live-registry path through the Embed encoder/decoder.
+class _LateLit(_Node):
+    kind: Literal["late"]
+    value: float = 0.0
+
+
+def test_embed_tagged_union_preserves_variant_identity_in_tuple() -> None:
+    c = _Container(
+        items=(
+            _Lit(kind="lit", value=1),
+            _Var(kind="var", name="x"),
+            _Lit(kind="lit", value=99),
+        )
+    )
+    types = [type(item).__name__ for item in c.items]
+    assert types == ["_Lit", "_Var", "_Lit"]
+    # The variant's own field is reachable on the recovered instance.
+    assert c.items[0].value == 1  # type: ignore[union-attr]
+    assert c.items[1].name == "x"  # type: ignore[union-attr]
+
+
+def test_embed_tagged_union_round_trips_through_json() -> None:
+    c = _Container(
+        items=(_Lit(kind="lit", value=7), _Var(kind="var", name="y")),
+    )
+    out = _Container.model_validate_json(c.model_dump_json())
+    types = [type(item).__name__ for item in out.items]
+    assert types == ["_Lit", "_Var"]
+    assert out.items[0].value == 7  # type: ignore[union-attr]
+    assert out.items[1].name == "y"  # type: ignore[union-attr]
+
+
+def test_embed_tagged_union_scalar_field_round_trip() -> None:
+    """Single (non-container) ``Embed[Root]`` field carries the variant too."""
+    c = _Container(head=_Var(kind="var", name="alpha"))
+    assert isinstance(c.head, _Var)
+    assert c.head.name == "alpha"
+    out = _Container.model_validate_json(c.model_dump_json())
+    assert isinstance(out.head, _Var)
+    assert out.head.name == "alpha"
+
+
+def test_embed_tagged_union_storage_round_trip() -> None:
+    """``from_storage_dict`` (the pickle path) round-trips variants too."""
+    c = _Container(items=(_Lit(kind="lit", value=42),))
+    storage = c.to_storage_dict()
+    recovered = _Container.from_storage_dict(storage)
+    assert isinstance(recovered.items[0], _Lit)
+    assert recovered.items[0].value == 42
+
+
+def test_embed_tagged_union_late_registered_variant_round_trips() -> None:
+    """Variants defined after the Embed-typed field's classify call work.
+
+    ``_LateLit`` is declared at module scope after ``_Container``; the
+    Embed encoder must therefore consult ``_Node.__variants__`` live
+    on every encode/decode call (the same pattern as #24's fix).
+    """
+    c = _Container(items=(_LateLit(kind="late", value=2.5),))
+    out = _Container.model_validate_json(c.model_dump_json())
+    assert isinstance(out.items[0], _LateLit)
+    assert out.items[0].value == 2.5  # type: ignore[union-attr]
+
+
+def test_embed_non_tagged_union_unaffected() -> None:
+    """Plain ``Embed[T]`` (no TaggedUnion) keeps the legacy behaviour."""
+    o = _Outer(inner=_Inner(x=5))
+    out = _Outer.model_validate_json(o.model_dump_json())
+    assert isinstance(out.inner, _Inner)
+    assert out.inner.x == 5
+
+
+def test_embed_tagged_union_unknown_discriminator_falls_back_to_root() -> None:
+    """A storage entry with an unregistered discriminator value decodes as the root.
+
+    Stale storage from a schema older than the current variant set
+    must not crash decoding; falling back to the root preserves what
+    we can. The variant-specific fields will not be reachable, but
+    the construction succeeds.
+    """
+    storage_w_bad_disc = {
+        "items": '["{\\"kind\\": \\"unregistered\\", \\"value\\": 1}"]',
+        "head": "null",
+    }
+    recovered = _Container.from_storage_dict(storage_w_bad_disc)
+    assert isinstance(recovered.items[0], _Node)
+    assert not isinstance(recovered.items[0], (_Lit, _Var))
+
+
+# Regression for the issue's exact repro.
+
+
+def test_issue_27_repro_module_scope() -> None:
+    """The exact repro from issue #27 against the module-scope classes.
+
+    Function-scope class definitions can't be used here because the
+    test module sets ``from __future__ import annotations``, so a
+    function-local class annotation like ``items: tuple[Embed[N], ...]``
+    becomes a ``ForwardRef`` that can't resolve outside the function.
+    The module-level ``_Container`` and ``_Lit`` cover the same shape.
+    """
+    w = _Container(items=(_Lit(kind="lit", value=1),))
+    assert type(w.items[0]).__name__ == "_Lit"
+    assert w.items[0].value == 1  # type: ignore[union-attr]
+
+
+def test_dict_input_is_dispatched_to_correct_variant() -> None:
+    """Construction with a dict child also resolves to the correct variant."""
+    c = _Container(
+        items=({"kind": "lit", "value": 11},),  # type: ignore[arg-type]
+    )
+    assert isinstance(c.items[0], _Lit)
+    assert c.items[0].value == 11
+
+
+def test_passing_wrong_type_still_errors() -> None:
+    """The dispatch fix doesn't loosen the input type check."""
+    with pytest.raises(dx.ValidationError):
+        _Container(items=(42,))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Embedding a TaggedUnion variant inside another Model's Embed-typed field stored the variant's full storage (with discriminator and variant-specific fields) but reconstructed it as the bare root class -- the variant's extra fields became unreachable. The Embed translation now dispatches on the stored discriminator at decode time. Closes #27.

## Motivation

Surfaced in the `bead` Pydantic→didactic migration. Every collection-of-constraints field (`ExperimentList.list_constraints: tuple[Embed[ListConstraint], ...]` with `UniquenessConstraint`/`BalanceConstraint`/`OrderingConstraint` variants, plus the `ItemTemplate` task-spec discriminator and AST-style nested-children fields) hits this. After #22 fixed the top-level `model_validate(...)` dispatch path, this was the last layer where a variant got silently downcast.

## Changes

- `packages/didactic/src/didactic/types/_types.py` -- `_embed_translation` detects at classify time whether the target is a TaggedUnion root, and adds a `_resolve_variant(items)` helper that reads the stored discriminator and looks the variant up in `target_cls.__variants__` *live* (mirrors the #24 live-registry fix). Reconstructs the embedded value via the variant subclass's `from_storage_dict`. Falls back to the root when the discriminator is missing (plain `Embed[T]`) or when the value isn't registered (stale storage).
- The encoder side was already correct (`isinstance(v, target_cls)` matches variant instances; `v.to_storage_dict()` writes the variant's full storage). No change there.

- `packages/didactic/tests/test_embed_tagged_union.py` (new, 10 tests).
- `CHANGELOG.md` -- `[0.5.2] - 2026-05-05` entry.
- All four packages bumped to 0.5.2.

## Tests

598 tests pass (10 new). Coverage:

- Variant identity preserved on construction + JSON round-trip + `from_storage_dict` (pickle path).
- Both container shapes: `tuple[Embed[Root], ...]` and bare `Embed[Root] | None`.
- Late-registered variant (declared after `_Container`'s field was classified) round-trips -- pins the live-registry contract.
- Plain `Embed[T]` (no TaggedUnion) keeps the legacy single-class behaviour unchanged.
- Stale storage with an unregistered discriminator value falls back to the root rather than crashing.
- Dict-input construction (`Container(items=({"kind": "lit", ...},))`) routes through the variant.
- Wrong-type input still surfaces as `ValidationError`.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (598 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible bug fix.** Plain `Embed[T]` (no TaggedUnion) decodes through the same `target_cls.from_storage_dict(items)` path as before. The new dispatch only fires when the target is a TaggedUnion root *and* the storage actually carries the discriminator; the fallback covers every other case.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.5.2]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #27.