### PR TITLE
fix(meta): @dataclass_transform declares kw_only_default=True (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-06
+
+### Fixed
+
+- ``ModelMeta``'s ``@dataclass_transform`` now declares
+  ``kw_only_default=True`` (it previously declared
+  ``kw_only_default=False``). Without this, type checkers in strict
+  mode rejected every subclass that added a non-default field after
+  a parent's default-bearing field with
+  ``"Fields without default values cannot appear after fields with
+  default values"`` (``reportGeneralTypeIssues``). The runtime
+  ``Model.__init__`` already accepted only keyword arguments, so the
+  flag flip just aligns the static contract with the runtime
+  behaviour. The natural shape (``Base`` carries auto-id /
+  timestamps with defaults; ``Subclass`` adds domain fields) now
+  passes pyright's strict-mode analysis without per-line
+  suppressions. ([#34])
+
+[#34]: https://github.com/panproto/didactic/issues/34
+
 ## [0.6.0] - 2026-05-06
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.6.0"
+version = "0.6.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.6.0"
+version = "0.6.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.6.0"
+version = "0.6.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.6.0"
+version = "0.6.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -69,7 +69,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -15,8 +15,14 @@ Notes
 The metaclass uses the ``@dataclass_transform`` decorator (PEP 681) to
 tell type checkers that derived classes synthesise an ``__init__``
 accepting each annotated field. Flags applied:
-``eq_default=True``, ``order_default=False``, ``kw_only_default=False``,
-``frozen_default=True``, ``field_specifiers=(Field, field)``.
+``eq_default=True``, ``order_default=False``, ``kw_only_default=True``,
+``frozen_default=True``, ``field_specifiers=(Field, field)``. The
+``kw_only_default=True`` flag matches the runtime ``Model.__init__``,
+which only accepts keyword arguments (no positional construction);
+without it, type checkers reject any subclass that adds a
+non-default field after a parent's default-bearing field, which
+is the natural shape for a base-with-id-and-timestamps and
+domain-specific subclasses.
 """
 
 from __future__ import annotations
@@ -319,7 +325,7 @@ def _build_field_spec(
 @dataclass_transform(
     eq_default=True,
     order_default=False,
-    kw_only_default=False,
+    kw_only_default=True,
     frozen_default=True,
     field_specifiers=(Field, field),
 )

--- a/packages/didactic/tests/test_dataclass_transform_kw_only.py
+++ b/packages/didactic/tests/test_dataclass_transform_kw_only.py
@@ -1,0 +1,65 @@
+"""Pin the dataclass-transform contract on ``ModelMeta``.
+
+didactic Models are constructed by keyword only (the runtime
+``Model.__init__`` rejects positional args). The metaclass must
+therefore advertise ``kw_only_default=True`` to type checkers via
+PEP 681's ``@dataclass_transform``. Without this, every subclass
+that adds a non-default field after a parent's default-bearing field
+trips ``reportGeneralTypeIssues`` -- a routine shape (Base with
+auto-id / timestamps, domain-specific Subclass) under strict pyright.
+
+This test pins the metaclass declaration so a later refactor can't
+silently regress the kw-only contract.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID, uuid4
+
+import didactic.api as dx
+from didactic.models._meta import ModelMeta
+
+
+# -- the dataclass_transform metadata is set at module-decoration time
+# and stored on the class as ``__dataclass_transform__``.
+
+
+def test_modelmeta_dataclass_transform_kw_only_default_is_true() -> None:
+    transform = cast("dict[str, object]", ModelMeta.__dataclass_transform__)  # type: ignore[attr-defined]
+    assert transform.get("kw_only_default") is True
+
+
+def test_modelmeta_dataclass_transform_frozen_default_is_true() -> None:
+    """Sanity check: the frozen contract still travels alongside kw-only."""
+    transform = cast("dict[str, object]", ModelMeta.__dataclass_transform__)  # type: ignore[attr-defined]
+    assert transform.get("frozen_default") is True
+
+
+# -- runtime regression: the issue's exact repro shape.
+
+
+class _Base(dx.Model):
+    id: UUID = dx.field(default_factory=uuid4)
+
+
+class _Sub(_Base):
+    name: str
+
+
+def test_subclass_with_required_field_after_parent_default_constructs() -> None:
+    """The shape pyright flagged at static-check time still works at runtime.
+
+    The fix is purely a type-checker contract change; this test makes
+    sure the runtime behaviour the contract describes hasn't drifted.
+    """
+    s = _Sub(name="x")
+    assert s.name == "x"
+    assert isinstance(s.id, UUID)
+
+
+def test_subclass_passes_id_explicitly_too() -> None:
+    """The default still applies when not overridden, and is overridable."""
+    fixed = UUID("00000000-0000-0000-0000-000000000001")
+    s = _Sub(id=fixed, name="y")
+    assert s.id == fixed

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

`ModelMeta`'s `@dataclass_transform` decorator declared `kw_only_default=False`, so type checkers in strict mode applied dataclass-style "fields without defaults must precede fields with defaults" validation to didactic Model subclasses -- even though the runtime `Model.__init__` only accepts keyword arguments. Flipping to `kw_only_default=True` aligns the static contract with the existing runtime behaviour. Closes #34.

## Motivation

Surfaced in `bead`'s `BeadBaseModel(dx.Model)`: every subclass that adds a required field after the base's defaulted `id`/`created_at`/`modified_at`/`version`/`metadata` tripped pyright with `reportGeneralTypeIssues`. The reporter measured 103 errors across `bead/data/metadata.py`, `bead/items/*.py`, `bead/lists/*.py`, `bead/resources/*.py`, `bead/config/*.py` -- effectively every domain model. Project-level pyright config could disable the rule, but that would hide genuine issues elsewhere; a one-line metaclass change is the right fix.

## Changes

- `packages/didactic/src/didactic/models/_meta.py` -- the `@dataclass_transform` decorator on `ModelMeta` now passes `kw_only_default=True`. Module docstring updated to reflect the new contract.
- `packages/didactic/tests/test_dataclass_transform_kw_only.py` (new, 4 tests).
- `CHANGELOG.md` -- `[0.6.1] - 2026-05-06` entry.
- All four packages bumped to 0.6.1.

## Tests

615 tests pass (4 new). Coverage:

- `ModelMeta.__dataclass_transform__` advertises `kw_only_default=True` (the marker the fix flips) and `frozen_default=True` (sanity-check that the existing contract still travels).
- Runtime regression: the issue's exact repro shape (`class Sub(Base): name: str` where `Base.id` has a `default_factory`) constructs cleanly via `Sub(name="x")`, applies the parent's default, and is overridable.

I also confirmed pyright clean on a standalone copy of the issue's repro file.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (615 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible.** Pure type-checker contract change; runtime behaviour was already kw-only. Any code that previously type-checked still type-checks; subclasses that previously failed strict pyright now pass without source changes.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.6.1]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #34.