### PR TITLE
fix(types): FieldValue mapping arm uses covariant Mapping (v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-06
+
+### Fixed
+
+- ``FieldValue``'s recursive mapping arm uses ``Mapping[str, FieldValue]``
+  (covariant in its value type) instead of the invariant
+  ``dict[str, FieldValue]``. ``dict`` is invariant in ``V``, so any
+  concrete ``dict[str, X]`` (where ``X`` is a structural subset of
+  ``FieldValue``) was rejected by type checkers at every
+  ``Model.with_(field=value)`` call site, forcing callers to insert
+  ``cast("dict[str, FieldValue]", ...)`` boilerplate. The runtime
+  contract is unchanged: every ``dict`` is also a ``Mapping``, and
+  the encoder pipeline's ``isinstance(v, dict)`` checks keep matching
+  real ``dict`` payloads. ([#36])
+
+[#36]: https://github.com/panproto/didactic/issues/36
+
 ## [0.6.1] - 2026-05-06
 
 ### Fixed

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.6.1"
+version = "0.6.2"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.6.1"
+version = "0.6.2"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -69,7 +69,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/types/_typing.py
+++ b/packages/didactic/src/didactic/types/_typing.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, ForwardRef, Protocol, runtime_checkable
 from uuid import UUID
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from didactic.fields._fields import MissingType
     from didactic.models._model import Model
 
@@ -72,6 +74,16 @@ type JsonObject = dict[str, JsonValue]
 
 #: Any value a [Model][didactic.api.Model] field can hold. Recursive: the
 #: container variants nest. ``"Model"`` covers ``Embed[T]`` field values.
+#:
+#: The mapping arm uses ``Mapping`` (covariant in its value type) rather
+#: than the invariant ``dict``. ``dict`` is invariant in ``V``, so without
+#: the looser bound a concrete ``dict[str, MetadataValue]`` (or any other
+#: ``dict[str, X]`` whose ``X`` is a structural subset of ``FieldValue``)
+#: would not be assignable to a ``FieldValue``-typed parameter -- forcing
+#: callers to cast through every ``with_(metadata=...)`` call site. The
+#: runtime contract is unchanged: every ``dict`` is also a ``Mapping``,
+#: and every ``isinstance(v, dict)`` check (in the encoder pipeline) keeps
+#: matching real ``dict`` payloads.
 type FieldValue = (
     str
     | int
@@ -86,7 +98,7 @@ type FieldValue = (
     | None
     | tuple[FieldValue, ...]
     | frozenset[FieldValue]
-    | dict[str, FieldValue]
+    | Mapping[str, FieldValue]
     | Model
 )
 

--- a/packages/didactic/tests/test_with_mapping_covariance.py
+++ b/packages/didactic/tests/test_with_mapping_covariance.py
@@ -19,9 +19,19 @@ import didactic.api as dx
 type _MyValue = str | int | None | dict[str, "_MyValue"] | tuple["_MyValue", ...]
 
 
+def _empty_metadata() -> dict[str, _MyValue]:
+    return {}
+
+
+def _empty_tagged_elements() -> dict[str, tuple[str, ...]]:
+    return {}
+
+
 class _Holder(dx.Model):
-    metadata: dict[str, _MyValue] = dx.field(default_factory=dict)
-    tagged_elements: dict[str, tuple[str, ...]] = dx.field(default_factory=dict)
+    metadata: dict[str, _MyValue] = dx.field(default_factory=_empty_metadata)
+    tagged_elements: dict[str, tuple[str, ...]] = dx.field(
+        default_factory=_empty_tagged_elements
+    )
 
 
 def test_with_accepts_typed_dict_str_to_my_value() -> None:

--- a/packages/didactic/tests/test_with_mapping_covariance.py
+++ b/packages/didactic/tests/test_with_mapping_covariance.py
@@ -1,0 +1,56 @@
+"""``Model.with_()`` accepts concrete ``dict[str, X]`` shapes without casts.
+
+Pins the v0.6.2 type-shape change: ``FieldValue``'s recursive mapping
+arm uses ``Mapping`` (covariant in its value type) instead of the
+invariant ``dict``. Without this, every call site that passes a
+typed ``dict[str, MyValue]`` to ``with_()`` had to cast through the
+``FieldValue`` union; with it, the natural form type-checks.
+
+These tests run at runtime; the type-checker contract is pinned by
+the issue-#36 PR description and the module-level pyright sweep that
+runs in CI.
+"""
+
+from __future__ import annotations
+
+import didactic.api as dx
+
+
+type _MyValue = str | int | None | dict[str, "_MyValue"] | tuple["_MyValue", ...]
+
+
+class _Holder(dx.Model):
+    metadata: dict[str, _MyValue] = dx.field(default_factory=dict)
+    tagged_elements: dict[str, tuple[str, ...]] = dx.field(default_factory=dict)
+
+
+def test_with_accepts_typed_dict_str_to_my_value() -> None:
+    """The issue's exact shape: ``dict[str, _MyValue]`` flows into ``with_()``."""
+    h = _Holder()
+    md: dict[str, _MyValue] = {"k": "v", "nested": {"inner": 42}}
+    new = h.with_(metadata=md)
+    assert new.metadata == md
+
+
+def test_with_accepts_typed_dict_str_to_tuple_of_str() -> None:
+    """``dict[str, tuple[str, ...]]`` is a structural subset of FieldValue."""
+    h = _Holder()
+    payload: dict[str, tuple[str, ...]] = {"row1": ("a", "b"), "row2": ("c",)}
+    new = h.with_(tagged_elements=payload)
+    assert new.tagged_elements == payload
+
+
+def test_with_accepts_inline_dict_literal() -> None:
+    """The natural ``with_(metadata={...})`` literal form keeps working."""
+    h = _Holder()
+    new = h.with_(metadata={"k": "v"})
+    assert new.metadata == {"k": "v"}
+
+
+def test_with_round_trips_through_model_dump() -> None:
+    """The looser type-checker contract preserves runtime semantics."""
+    h = _Holder()
+    new = h.with_(metadata={"a": 1, "b": "two", "c": None})
+    payload = new.model_dump_json()
+    out = _Holder.model_validate_json(payload)
+    assert out.metadata == {"a": 1, "b": "two", "c": None}

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +211,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +226,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

`FieldValue`'s recursive mapping arm was `dict[str, FieldValue]`. `dict` is invariant in its value type, so any concrete `dict[str, X]` -- where `X` is a structural subset of `FieldValue` -- failed assignment to a `FieldValue`-typed parameter. Every `Model.with_(metadata=...)` / `with_(item_metadata=...)` call site had to insert a `cast("dict[str, FieldValue]", ...)`. Switching the alias to `Mapping[str, FieldValue]` (covariant in `V`) clears the false-positive without changing runtime behaviour. Closes #36.

## Motivation

The reporter measured ~10 of the remaining strict-pyright errors in `bead` after the kw_only fix from #34, all of the shape:

```
Argument of type "dict[str, MetadataValue]" cannot be assigned to parameter "item_metadata" of type "FieldValue" in function "with_"
Argument of type "BalanceMetrics" cannot be assigned to parameter "balance_metrics" of type "FieldValue" in function "with_"
Argument of type "dict[str, JsonValue]" cannot be assigned to parameter "participant_metadata" of type "FieldValue" in function "with_"
```

The natural call form (`m.with_(metadata={"k": "v"})`) was the canonical example: a plain dict literal with a structurally-compatible value type. The cast workaround is ugly and erases information; a one-line type-alias change is the right fix.

## Changes

- `packages/didactic/src/didactic/types/_typing.py` -- `FieldValue`'s recursive arm changes from `dict[str, FieldValue]` to `Mapping[str, FieldValue]`. The `Mapping` import is added under `TYPE_CHECKING`. Module docstring on the alias explains the variance reasoning.
- `packages/didactic/tests/test_with_mapping_covariance.py` (new, 4 tests).
- `CHANGELOG.md` -- `[0.6.2] - 2026-05-06` entry.
- All four packages bumped to 0.6.2.

## Tests

619 tests pass (4 new). Coverage:

- The issue's exact `dict[str, _MyValue]` shape through `with_()`.
- `dict[str, tuple[str, ...]]` (one of the bead failure shapes).
- Inline `with_(metadata={"k": "v"})` literal form.
- JSON round-trip after `with_()` to confirm the looser type contract preserves runtime semantics.

I also confirmed pyright clean on a standalone copy of the issue's repro.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (619 passed)
- [x] `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict` (0 warnings)

## Compatibility

- **Backwards-compatible.** Pure type-checker contract widening; no runtime behaviour changes. Every `dict` is a `Mapping`, so any existing call site that previously type-checked still type-checks. The encoder pipeline's `isinstance(v, dict)` checks continue to match real `dict` payloads (which are the only ones callers construct).

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.6.2]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #36.