### PR TITLE
feat: bare-Model fields + opaque fields + cinder docs theme (v0.7.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,4 @@ jobs:
       - run: uv python install 3.14
       - run: uv sync --all-packages --all-extras
       - name: build docs (strict)
-        env:
-          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,6 @@ jobs:
         run: uv sync --all-packages --all-extras
 
       - name: build site (strict)
-        env:
-          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict --site-dir site
 
       - name: configure pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,6 @@ jobs:
         run: uv run pytest -ra
 
       - name: docs build (strict)
-        env:
-          NO_MKDOCS_2_WARNING: "1"
         run: uv run mkdocs build --strict
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-07
+
+### Added
+
+- ``tuple[Model, ...]`` (and ``dict[str, Model]``, plain
+  ``inner: Model``) now classifies any ``dx.Model`` subclass used
+  directly as a field type. The classification routes through the
+  same Embed-shaped translation that ``Embed[T]`` would have built,
+  so the wire format and runtime semantics are identical and
+  callers no longer need a single-variant ``TaggedUnion`` wrapper to
+  collect heterogeneous record tuples. Models that are
+  ``TaggedUnion`` roots or variants stay on the discriminated path.
+  ([#38])
+- ``dx.field(opaque=True)`` declares a field that holds any Python
+  value by reference and skips the type-classification pipeline
+  entirely. The runtime stores the value on a per-instance
+  ``_opaque_storage`` side table; attribute access returns it
+  identity-equal; ``with_(...)`` updates it without
+  re-classification. JSON output writes ``null`` for opaque fields,
+  and ``model_validate_json`` does not reconstruct the value: opaque
+  fields explicitly do not round-trip through serialisation. Useful
+  for fields that carry a runtime-only handle (a typeclass instance,
+  a callback, a foreign object) where panproto schema integration is
+  not the goal. ([#39])
+
+### Changed
+
+- The documentation site uses the cinder theme. The previous
+  Material configuration is replaced by ``theme: name: cinder`` plus
+  a small ``docs/css/`` palette covering pygments token colours and
+  mkdocstrings layout. CI no longer needs the
+  ``NO_MKDOCS_2_WARNING`` workaround; the same env var has been
+  removed from ``ci.yml`` / ``docs.yml`` / ``release.yml`` and from
+  the README's local-build snippet.
+
+[#38]: https://github.com/panproto/didactic/issues/38
+[#39]: https://github.com/panproto/didactic/issues/39
+
 ## [0.6.2] - 2026-05-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -146,12 +146,8 @@ uv run pytest
 uv run ruff format
 uv run ruff check
 uv run pyright
-NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict
+uv run mkdocs build --strict
 ```
-
-The `NO_MKDOCS_2_WARNING` env var silences the marketing banner that
-the `mkdocs-material` package prints unconditionally to stderr; CI
-sets it for the same reason.
 
 CI runs lint, pyright, pytest, and the docs build on Linux and macOS
 for every PR.

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,87 @@
+/* code blocks: dark grey background */
+.codehilite,
+.highlight {
+    background: #2b2b2b !important;
+    border-radius: 6px;
+    padding: 0.8em 1em;
+}
+
+.codehilite pre,
+.highlight pre {
+    background: transparent !important;
+    margin: 0;
+}
+
+pre code {
+    font-size: 0.9em;
+    color: #f8f8f2;
+}
+
+/* API docs from mkdocstrings */
+.doc-heading code {
+    font-size: 1.1em;
+}
+
+.doc-contents {
+    padding-left: 1.5em;
+    border-left: 3px solid #eee;
+}
+
+/* ================================================================
+   Pygments token coloring for the dark code-block background.
+   Targets both .codehilite and .highlight wrappers.
+   ================================================================ */
+
+/* declaration keywords */
+.codehilite .kd, .highlight .kd { color: #c792ea !important; font-weight: bold !important; }
+
+/* reserved keywords */
+.codehilite .kr, .highlight .kr { color: #ff79c6 !important; font-weight: bold !important; }
+
+/* type keywords / type annotations */
+.codehilite .kt, .highlight .kt { color: #82aaff !important; font-weight: bold !important; }
+
+/* decorators (Name.Decorator) */
+.codehilite .nd, .highlight .nd { color: #ffcb6b !important; font-weight: bold !important; }
+
+/* class names (Name.Class) */
+.codehilite .nc, .highlight .nc { color: #89ddff !important; font-weight: bold !important; }
+
+/* built-in functions (Name.Builtin) */
+.codehilite .nb, .highlight .nb { color: #c3e88d !important; }
+
+/* constants (Name.Constant) */
+.codehilite .no, .highlight .no { color: #c3e88d !important; font-style: italic !important; }
+
+/* string symbols */
+.codehilite .ss, .highlight .ss { color: #c3e88d !important; font-style: italic !important; }
+
+/* keyword arguments (Name.Attribute) */
+.codehilite .na, .highlight .na { color: #ffcb6b !important; }
+
+/* variable names (Name.Variable) */
+.codehilite .nv, .highlight .nv { color: #eeffff !important; }
+
+/* arithmetic / structural operators */
+.codehilite .o, .highlight .o { color: #89ddff !important; }
+
+/* numbers */
+.codehilite .mf, .highlight .mf { color: #f78c6c !important; }
+.codehilite .mi, .highlight .mi { color: #f78c6c !important; }
+
+/* comments */
+.codehilite .c1, .highlight .c1 { color: #7c8fa4 !important; font-style: italic !important; }
+
+/* punctuation */
+.codehilite .p, .highlight .p { color: #89ddff !important; }
+
+/* generic keyword fallback */
+.codehilite .k, .highlight .k { color: #c792ea !important; font-weight: bold !important; }
+
+/* generic name fallback */
+.codehilite .n, .highlight .n { color: #eeffff !important; }
+
+/* string literals */
+.codehilite .s, .highlight .s,
+.codehilite .s1, .highlight .s1,
+.codehilite .s2, .highlight .s2 { color: #c3e88d !important; }

--- a/docs/css/pygments.css
+++ b/docs/css/pygments.css
@@ -1,0 +1,85 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.codehilite .hll, .highlight .hll { background-color: #49483e }
+.codehilite , .highlight { background: #272822; color: #F8F8F2 }
+.codehilite .c, .highlight .c { color: #959077 } /* Comment */
+.codehilite .err, .highlight .err { color: #ED007E; background-color: #1E0010 } /* Error */
+.codehilite .esc, .highlight .esc { color: #F8F8F2 } /* Escape */
+.codehilite .g, .highlight .g { color: #F8F8F2 } /* Generic */
+.codehilite .k, .highlight .k { color: #66D9EF } /* Keyword */
+.codehilite .l, .highlight .l { color: #AE81FF } /* Literal */
+.codehilite .n, .highlight .n { color: #F8F8F2 } /* Name */
+.codehilite .o, .highlight .o { color: #FF4689 } /* Operator */
+.codehilite .x, .highlight .x { color: #F8F8F2 } /* Other */
+.codehilite .p, .highlight .p { color: #F8F8F2 } /* Punctuation */
+.codehilite .ch, .highlight .ch { color: #959077 } /* Comment.Hashbang */
+.codehilite .cm, .highlight .cm { color: #959077 } /* Comment.Multiline */
+.codehilite .cp, .highlight .cp { color: #959077 } /* Comment.Preproc */
+.codehilite .cpf, .highlight .cpf { color: #959077 } /* Comment.PreprocFile */
+.codehilite .c1, .highlight .c1 { color: #959077 } /* Comment.Single */
+.codehilite .cs, .highlight .cs { color: #959077 } /* Comment.Special */
+.codehilite .gd, .highlight .gd { color: #FF4689 } /* Generic.Deleted */
+.codehilite .ge, .highlight .ge { color: #F8F8F2; font-style: italic } /* Generic.Emph */
+.codehilite .ges, .highlight .ges { color: #F8F8F2; font-weight: bold; font-style: italic } /* Generic.EmphStrong */
+.codehilite .gr, .highlight .gr { color: #F8F8F2 } /* Generic.Error */
+.codehilite .gh, .highlight .gh { color: #F8F8F2 } /* Generic.Heading */
+.codehilite .gi, .highlight .gi { color: #A6E22E } /* Generic.Inserted */
+.codehilite .go, .highlight .go { color: #66D9EF } /* Generic.Output */
+.codehilite .gp, .highlight .gp { color: #FF4689; font-weight: bold } /* Generic.Prompt */
+.codehilite .gs, .highlight .gs { color: #F8F8F2; font-weight: bold } /* Generic.Strong */
+.codehilite .gu, .highlight .gu { color: #959077 } /* Generic.Subheading */
+.codehilite .gt, .highlight .gt { color: #F8F8F2 } /* Generic.Traceback */
+.codehilite .kc, .highlight .kc { color: #66D9EF } /* Keyword.Constant */
+.codehilite .kd, .highlight .kd { color: #66D9EF } /* Keyword.Declaration */
+.codehilite .kn, .highlight .kn { color: #FF4689 } /* Keyword.Namespace */
+.codehilite .kp, .highlight .kp { color: #66D9EF } /* Keyword.Pseudo */
+.codehilite .kr, .highlight .kr { color: #66D9EF } /* Keyword.Reserved */
+.codehilite .kt, .highlight .kt { color: #66D9EF } /* Keyword.Type */
+.codehilite .ld, .highlight .ld { color: #E6DB74 } /* Literal.Date */
+.codehilite .m, .highlight .m { color: #AE81FF } /* Literal.Number */
+.codehilite .s, .highlight .s { color: #E6DB74 } /* Literal.String */
+.codehilite .na, .highlight .na { color: #A6E22E } /* Name.Attribute */
+.codehilite .nb, .highlight .nb { color: #F8F8F2 } /* Name.Builtin */
+.codehilite .nc, .highlight .nc { color: #A6E22E } /* Name.Class */
+.codehilite .no, .highlight .no { color: #66D9EF } /* Name.Constant */
+.codehilite .nd, .highlight .nd { color: #A6E22E } /* Name.Decorator */
+.codehilite .ni, .highlight .ni { color: #F8F8F2 } /* Name.Entity */
+.codehilite .ne, .highlight .ne { color: #A6E22E } /* Name.Exception */
+.codehilite .nf, .highlight .nf { color: #A6E22E } /* Name.Function */
+.codehilite .nl, .highlight .nl { color: #F8F8F2 } /* Name.Label */
+.codehilite .nn, .highlight .nn { color: #F8F8F2 } /* Name.Namespace */
+.codehilite .nx, .highlight .nx { color: #A6E22E } /* Name.Other */
+.codehilite .py, .highlight .py { color: #F8F8F2 } /* Name.Property */
+.codehilite .nt, .highlight .nt { color: #FF4689 } /* Name.Tag */
+.codehilite .nv, .highlight .nv { color: #F8F8F2 } /* Name.Variable */
+.codehilite .ow, .highlight .ow { color: #FF4689 } /* Operator.Word */
+.codehilite .pm, .highlight .pm { color: #F8F8F2 } /* Punctuation.Marker */
+.codehilite .w, .highlight .w { color: #F8F8F2 } /* Text.Whitespace */
+.codehilite .mb, .highlight .mb { color: #AE81FF } /* Literal.Number.Bin */
+.codehilite .mf, .highlight .mf { color: #AE81FF } /* Literal.Number.Float */
+.codehilite .mh, .highlight .mh { color: #AE81FF } /* Literal.Number.Hex */
+.codehilite .mi, .highlight .mi { color: #AE81FF } /* Literal.Number.Integer */
+.codehilite .mo, .highlight .mo { color: #AE81FF } /* Literal.Number.Oct */
+.codehilite .sa, .highlight .sa { color: #E6DB74 } /* Literal.String.Affix */
+.codehilite .sb, .highlight .sb { color: #E6DB74 } /* Literal.String.Backtick */
+.codehilite .sc, .highlight .sc { color: #E6DB74 } /* Literal.String.Char */
+.codehilite .dl, .highlight .dl { color: #E6DB74 } /* Literal.String.Delimiter */
+.codehilite .sd, .highlight .sd { color: #E6DB74 } /* Literal.String.Doc */
+.codehilite .s2, .highlight .s2 { color: #E6DB74 } /* Literal.String.Double */
+.codehilite .se, .highlight .se { color: #AE81FF } /* Literal.String.Escape */
+.codehilite .sh, .highlight .sh { color: #E6DB74 } /* Literal.String.Heredoc */
+.codehilite .si, .highlight .si { color: #E6DB74 } /* Literal.String.Interpol */
+.codehilite .sx, .highlight .sx { color: #E6DB74 } /* Literal.String.Other */
+.codehilite .sr, .highlight .sr { color: #E6DB74 } /* Literal.String.Regex */
+.codehilite .s1, .highlight .s1 { color: #E6DB74 } /* Literal.String.Single */
+.codehilite .ss, .highlight .ss { color: #E6DB74 } /* Literal.String.Symbol */
+.codehilite .bp, .highlight .bp { color: #F8F8F2 } /* Name.Builtin.Pseudo */
+.codehilite .fm, .highlight .fm { color: #A6E22E } /* Name.Function.Magic */
+.codehilite .vc, .highlight .vc { color: #F8F8F2 } /* Name.Variable.Class */
+.codehilite .vg, .highlight .vg { color: #F8F8F2 } /* Name.Variable.Global */
+.codehilite .vi, .highlight .vi { color: #F8F8F2 } /* Name.Variable.Instance */
+.codehilite .vm, .highlight .vm { color: #F8F8F2 } /* Name.Variable.Magic */
+.codehilite .il, .highlight .il { color: #AE81FF } /* Literal.Number.Integer.Long */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,52 +1,36 @@
 site_name: didactic
 site_description: A typed-data library on top of panproto. Models, lenses, migrations, version control, multi-format codegen.
 site_url: https://panproto.dev/didactic/
+site_author: panproto contributors
 repo_url: https://github.com/panproto/didactic
 repo_name: panproto/didactic
 edit_uri: edit/main/docs/
 
 theme:
-  name: material
-  features:
-    - navigation.sections
-    - navigation.expand
-    - navigation.indexes
-    - navigation.top
-    - navigation.tabs
-    - content.code.copy
-    - content.code.annotate
-    - search.suggest
-    - search.highlight
-    - toc.follow
-  palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: deep purple
-      accent: indigo
-      toggle:
-        icon: material/weather-sunny
-        name: switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: deep purple
-      accent: indigo
-      toggle:
-        icon: material/weather-night
-        name: switch to light mode
+  name: cinder
+  highlightjs: false
+
+extra_css:
+  - css/pygments.css
+  - css/custom.css
 
 markdown_extensions:
   - admonition
   - attr_list
+  - def_list
+  - footnotes
   - md_in_html
+  - tables
   - pymdownx.details
   - pymdownx.highlight:
+      use_pygments: true
+      guess_lang: false
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
-  - tables
   - toc:
       permalink: true
 
@@ -54,6 +38,7 @@ plugins:
   - search
   - autorefs
   - mkdocstrings:
+      default_handler: python
       handlers:
         python:
           paths:
@@ -63,7 +48,7 @@ plugins:
             - packages/didactic-fastapi/src
           options:
             docstring_style: numpy
-            docstring_section_style: table
+            docstring_section_style: spacy
             show_root_heading: true
             show_source: false
             show_signature_annotations: true
@@ -72,6 +57,7 @@ plugins:
             merge_init_into_class: true
             inherited_members: false
             members_order: source
+            heading_level: 2
             filters:
               - "!^_"
               - "^__init__$"

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.6.2"
+version = "0.7.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.6.2"
+version = "0.7.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.6.2"
+version = "0.7.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.6.2"
+version = "0.7.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -69,7 +69,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/fields/_fields.py
+++ b/packages/didactic/src/didactic/fields/_fields.py
@@ -188,6 +188,7 @@ class Field:
     coercion: Callable[..., FieldValue] | None = None
     usage_mode: Literal["readwrite", "computed", "materialised"] = "readwrite"
     extras: Mapping[str, Opaque] | None = None
+    opaque: bool = False
 
     def __post_init__(self) -> None:
         """Validate exclusive options."""
@@ -210,6 +211,7 @@ def field[T](
     coercion: Callable[..., FieldValue] | None = ...,
     usage_mode: Literal["readwrite", "computed", "materialised"] = ...,
     extras: Mapping[str, Opaque] | None = ...,
+    opaque: bool = ...,
 ) -> T: ...
 @overload
 def field[T](
@@ -225,6 +227,7 @@ def field[T](
     coercion: Callable[..., FieldValue] | None = ...,
     usage_mode: Literal["readwrite", "computed", "materialised"] = ...,
     extras: Mapping[str, Opaque] | None = ...,
+    opaque: bool = ...,
 ) -> T: ...
 @overload
 def field(
@@ -239,6 +242,7 @@ def field(
     coercion: Callable[..., FieldValue] | None = ...,
     usage_mode: Literal["readwrite", "computed", "materialised"] = ...,
     extras: Mapping[str, Opaque] | None = ...,
+    opaque: bool = ...,
 ) -> Any: ...  # documented escape hatch for required-with-metadata fields
 def field(
     *,
@@ -254,6 +258,7 @@ def field(
     coercion: Callable[..., FieldValue] | None = None,
     usage_mode: Literal["readwrite", "computed", "materialised"] = "readwrite",
     extras: Mapping[str, Opaque] | None = None,
+    opaque: bool = False,
 ) -> Field:
     """Construct a [Field][didactic.api.Field] descriptor.
 
@@ -323,6 +328,7 @@ def field(
         coercion=coercion,
         usage_mode=usage_mode,
         extras=extras,
+        opaque=opaque,
     )
 
 
@@ -390,6 +396,7 @@ class FieldSpec:
     extras: Mapping[str, Opaque] = _dc_field(
         default_factory=lambda: cast("dict[str, Opaque]", {})
     )
+    is_opaque: bool = False
 
     @property
     def is_required(self) -> bool:

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -50,7 +50,7 @@ from didactic.fields._fields import (
     read_annotated_metadata,
 )
 from didactic.models._config import DEFAULT_CONFIG, ExtraPolicy, ModelConfig
-from didactic.types._types import TypeForm, classify
+from didactic.types._types import TypeForm, classify, make_opaque_translation
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -282,6 +282,33 @@ def _build_field_spec(
     # to drop the residual ``TypeVar | ForwardRef`` arms from pyright's
     # view.
     type_form = cast("TypeForm", annotation)
+
+    # ``dx.field(opaque=True)`` short-circuits the type-classification
+    # path: the annotation is read for documentation, but the value is
+    # stored by-reference on the instance and never round-trips through
+    # the encoded storage. Use ``make_opaque_translation`` so the FieldSpec
+    # has a translation object the rest of the pipeline can pattern-match
+    # without a None check; the encode/decode never actually run because
+    # ``Model.__init__`` skips them for opaque fields.
+    if isinstance(raw_default, Field) and raw_default.opaque:
+        f = raw_default
+        return FieldSpec(
+            name=name,
+            annotation=annotation,
+            translation=make_opaque_translation(),
+            default=f.default,
+            default_factory=f.default_factory,
+            converter=f.converter,
+            alias=f.alias,
+            description=f.description,
+            examples=f.examples,
+            deprecated=f.deprecated,
+            nominal=f.nominal,
+            usage_mode=f.usage_mode,
+            extras=dict(f.extras) if f.extras else {},
+            is_opaque=True,
+        )
+
     translation = classify(type_form)
     annotated_meta = read_annotated_metadata(type_form)
 

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -97,7 +97,7 @@ class Model(metaclass=ModelMeta):
     # are deliberately not declared as class-level annotations so the
     # metaclass's ``@dataclass_transform`` does not surface them as
     # synthesized ``__init__`` parameters in subclass type-checking.
-    __slots__ = ("_derived_cache", "_storage")
+    __slots__ = ("_derived_cache", "_opaque_storage", "_storage")
 
     # Class-level attributes synthesized by the metaclass at class
     # creation time. Declared here so type checkers see them on every
@@ -160,6 +160,7 @@ class Model(metaclass=ModelMeta):
         specs = cls.__field_specs__
 
         encoded: dict[str, Encoded] = {}
+        opaque_storage: dict[str, object] = {}
         errors: list[ValidationErrorEntry] = []
 
         # collect known kwargs
@@ -183,6 +184,14 @@ class Model(metaclass=ModelMeta):
                     msg = f"non-required field {fname!r} returned MISSING"
                     raise AssertionError(msg)
                 value = default
+
+            # Opaque fields skip the encoder entirely; the value sits in
+            # the per-instance ``_opaque_storage`` side table and the
+            # encoded ``_storage`` carries a deterministic placeholder.
+            if spec.is_opaque:
+                opaque_storage[fname] = value
+                encoded[fname] = "null"
+                continue
 
             try:
                 encoded_value = _run_field_pipeline(
@@ -239,6 +248,7 @@ class Model(metaclass=ModelMeta):
         # bypass our own __setattr__ guard
         object.__setattr__(self, "_storage", DictStorage(encoded))
         object.__setattr__(self, "_derived_cache", {})
+        object.__setattr__(self, "_opaque_storage", opaque_storage)
 
         # axiom enforcement: each class-level axiom is parsed via
         # panproto.parse_expr and evaluated against the field environment
@@ -310,6 +320,9 @@ class Model(metaclass=ModelMeta):
         except KeyError:
             msg = f"{cls.__name__!r} has no field {name!r}"
             raise AttributeError(msg) from None
+        if spec.is_opaque:
+            opaque_storage = cast("dict[str, object]", self._opaque_storage)
+            return cast("FieldValue", opaque_storage[name])
         encoded = self._storage.get(name)
         return spec.translation.decode(encoded)
 
@@ -345,6 +358,7 @@ class Model(metaclass=ModelMeta):
         specs = cls.__field_specs__
         errors: list[ValidationErrorEntry] = []
         encoded: dict[str, Encoded] = {}
+        opaque_overrides: dict[str, object] = {}
 
         for k, v in changes.items():
             if k not in specs:
@@ -355,6 +369,9 @@ class Model(metaclass=ModelMeta):
                         msg=f"unknown field {k!r}",
                     )
                 )
+                continue
+            if specs[k].is_opaque:
+                opaque_overrides[k] = v
                 continue
             try:
                 encoded[k] = _run_field_pipeline(cls, specs[k], k, v)
@@ -375,6 +392,12 @@ class Model(metaclass=ModelMeta):
         new_storage = self._storage.replaced(encoded)
         new = cls.__new__(cls)
         object.__setattr__(new, "_storage", new_storage)
+        # carry the existing opaque-storage forward, then apply overrides
+        old_opaque = cast("dict[str, object]", self._opaque_storage)
+        new_opaque = dict(old_opaque)
+        new_opaque.update(opaque_overrides)
+        object.__setattr__(new, "_opaque_storage", new_opaque)
+        object.__setattr__(new, "_derived_cache", {})
         return new
 
     # -- serialisation ------------------------------------------------------
@@ -424,6 +447,18 @@ class Model(metaclass=ModelMeta):
             if include is not None and fname not in include:
                 continue
             if exclude is not None and fname in exclude:
+                continue
+            # Opaque fields don't round-trip through the encoder; their
+            # value lives in the per-instance side table. ``model_dump``
+            # is a JSON-shaped projection, so an opaque value (which
+            # doesn't have a JSON form by contract) is rendered as
+            # ``None``. Callers that need to inspect the live object
+            # use direct attribute access; ``model_dump`` is for
+            # serialisation paths that explicitly skip opaque fields.
+            if spec.is_opaque:
+                key = spec.alias if by_alias and spec.alias else fname
+                if not exclude_none:
+                    result[key] = None
                 continue
             value = spec.translation.decode(self._storage.get(fname))
             if exclude_none and value is None:
@@ -695,8 +730,7 @@ class Model(metaclass=ModelMeta):
         """Pydantic-style ``ClassName(field=value, ...)`` repr."""
         cls = type(self)
         parts = ", ".join(
-            f"{fname}={spec.translation.decode(self._storage.get(fname))!r}"
-            for fname, spec in cls.__field_specs__.items()
+            f"{fname}={getattr(self, fname)!r}" for fname in cls.__field_specs__
         )
         return f"{cls.__name__}({parts})"
 
@@ -729,6 +763,13 @@ class Model(metaclass=ModelMeta):
         """
         new = cls.__new__(cls)
         object.__setattr__(new, "_storage", DictStorage(items))
+        object.__setattr__(new, "_derived_cache", {})
+        # opaque fields don't survive a pure storage-dict round-trip
+        # (their values live in a per-instance side table that ``items``
+        # doesn't carry); seed an empty side table so ``__getattr__``
+        # produces a clear KeyError if anyone reads an opaque field on
+        # a from_storage_dict-built instance.
+        object.__setattr__(new, "_opaque_storage", {})
         return new
 
     def to_storage_dict(self) -> dict[str, str]:
@@ -771,6 +812,9 @@ class Model(metaclass=ModelMeta):
         """
         object.__setattr__(self, "_storage", DictStorage(state))
         object.__setattr__(self, "_derived_cache", {})
+        # opaque fields aren't pickle-encoded (their values live by
+        # reference); seed an empty side table.
+        object.__setattr__(self, "_opaque_storage", {})
 
 
 # ---------------------------------------------------------------------------

--- a/packages/didactic/src/didactic/types/_types.py
+++ b/packages/didactic/src/didactic/types/_types.py
@@ -1934,6 +1934,17 @@ def classify(typ: TypeForm) -> TypeTranslation:
     if isinstance(inner_type, type) and _is_tagged_union_root(inner_type):
         return _tagged_union_translation(inner_type)
 
+    # Bare ``dx.Model`` subclass used as a field type (``items:
+    # tuple[Operation, ...]``, ``inner: Operation``). Treat the
+    # annotation as if it had been written ``Embed[T]`` -- the wire
+    # contract and runtime semantics are identical, and forcing
+    # callers to spell out ``Embed`` for every nested record produces
+    # boilerplate without information gain. Models that are
+    # ``TaggedUnion`` roots have already been routed to the discriminated
+    # path above.
+    if isinstance(inner_type, type) and _is_bare_model_field_target(inner_type):
+        return _bare_model_translation(inner_type)
+
     # parameterised generics
     origin = get_origin(inner_type)
     args = get_args(inner_type)
@@ -2059,6 +2070,79 @@ def _has_embed_marker(metadata: tuple[Opaque, ...]) -> bool:
     from didactic.fields._refs import EmbedSentinel  # noqa: PLC0415
 
     return any(isinstance(m, EmbedSentinel) for m in metadata)
+
+
+def _is_bare_model_field_target(cls: type) -> bool:
+    """Tell whether ``cls`` is a bare ``dx.Model`` usable as ``Embed[cls]``.
+
+    Returns False for ``Model`` itself, for ``TaggedUnion`` (the union
+    base class), and for any subclass that is also a ``TaggedUnion``
+    root or one of its variants -- those have their own field-type
+    classification path. Unparameterised generic Models are also
+    excluded since their fields can't round-trip until parameterised.
+    """
+    from didactic.fields._unions import TaggedUnion  # noqa: PLC0415
+    from didactic.models._model import Model  # noqa: PLC0415
+
+    if cls is Model or cls is TaggedUnion:
+        return False
+    if not issubclass(cls, Model):
+        return False
+    # Variants and roots both go through the discriminated path: variants
+    # because they're handled inside the root's translation, roots because
+    # the bare-Model path would lose the dispatch shape.
+    return not issubclass(cls, TaggedUnion)
+
+
+def _bare_model_translation(target_cls: type) -> TypeTranslation:
+    """Build the Embed-shaped translation for a bare ``dx.Model`` field type.
+
+    Synthesises the same ``TypeTranslation`` that
+    ``_embed_translation(target_cls, (EmbedSentinel(),))`` would build,
+    without the caller having to spell ``Embed[T]``. The wire format
+    and runtime semantics are identical to the explicit-Embed path.
+    """
+    from didactic.fields._refs import EmbedSentinel  # noqa: PLC0415
+
+    return _embed_translation(target_cls, (EmbedSentinel(),))
+
+
+def make_opaque_translation() -> TypeTranslation:
+    """Build the translation used for ``dx.field(opaque=True)`` fields.
+
+    The encode/decode pair is never actually invoked: ``Model.__init__``
+    short-circuits opaque fields and stores the raw value in a
+    per-instance side table (``_opaque_storage``); ``__getattr__``
+    pulls from that table without going through the encoded
+    ``_storage``. The translation exists only so the rest of the
+    machinery (FieldSpec, Theory build, codegen tooling) has something
+    to pattern-match without a special-case ``None`` check.
+
+    The wire-format functions return defensive sentinels so any caller
+    that *does* route an opaque field through them (e.g. a stale
+    ``model_validate_json`` payload) sees a clear error rather than a
+    silently-corrupted value.
+    """
+
+    def enc(_: FieldValue) -> Encoded:
+        msg = "opaque fields do not round-trip through the encoder"
+        raise TypeError(msg)
+
+    def dec(_: Encoded) -> FieldValue:
+        msg = "opaque fields do not round-trip through the decoder"
+        raise TypeError(msg)
+
+    def from_json(_: JsonValue) -> FieldValue:
+        msg = "opaque fields do not round-trip from JSON"
+        raise TypeError(msg)
+
+    return TypeTranslation(
+        sort="Opaque",
+        encode=enc,
+        decode=dec,
+        inner_kind="opaque",
+        from_json=from_json,
+    )
 
 
 def _embed_translation(base: TypeForm, metadata: tuple[Opaque, ...]) -> TypeTranslation:

--- a/packages/didactic/tests/test_bare_model_field.py
+++ b/packages/didactic/tests/test_bare_model_field.py
@@ -1,0 +1,76 @@
+"""``tuple[Model, ...]`` and bare-Model fields without explicit ``Embed``.
+
+A ``dx.Model`` subclass used directly as a field type classifies
+through the same Embed-shaped translation that ``Embed[T]`` would
+have produced; the wire format and runtime semantics are identical.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import didactic.api as dx
+
+
+class _Operation(dx.Model):
+    name: str
+    arity: int = 0
+
+
+class _EffectSignature(dx.Model):
+    operations: tuple[_Operation, ...] = ()
+
+
+class _Container(dx.Model):
+    """Mix bare-Model fields with the existing Embed/scalar shapes."""
+
+    head: _Operation
+    body: tuple[_Operation, ...] = ()
+    by_name: dict[str, _Operation] = dx.field(
+        default_factory=lambda: cast("dict[str, _Operation]", {})
+    )
+
+
+def test_tuple_of_bare_model_constructs() -> None:
+    s = _EffectSignature(
+        operations=(_Operation(name="a"), _Operation(name="b", arity=2))
+    )
+    assert len(s.operations) == 2
+    assert s.operations[0].name == "a"
+    assert s.operations[1].arity == 2
+
+
+def test_tuple_of_bare_model_round_trips_json() -> None:
+    s = _EffectSignature(
+        operations=(_Operation(name="a"), _Operation(name="b", arity=2))
+    )
+    out = _EffectSignature.model_validate_json(s.model_dump_json())
+    assert out == s
+    assert isinstance(out.operations[0], _Operation)
+
+
+def test_bare_model_scalar_field_works() -> None:
+    """``head: _Operation`` (no container) routes through Embed too."""
+    c = _Container(head=_Operation(name="x"))
+    assert isinstance(c.head, _Operation)
+    rt = _Container.model_validate_json(c.model_dump_json())
+    assert rt.head.name == "x"
+
+
+def test_dict_of_bare_model_round_trips() -> None:
+    c = _Container(
+        head=_Operation(name="root"),
+        by_name={"a": _Operation(name="a"), "b": _Operation(name="b")},
+    )
+    rt = _Container.model_validate_json(c.model_dump_json())
+    assert set(rt.by_name) == {"a", "b"}
+    assert isinstance(rt.by_name["a"], _Operation)
+
+
+def test_bare_model_dict_input_dispatches_through_construction() -> None:
+    """Construction with a dict child runs the embed encoder's coercion path."""
+    s = _EffectSignature(
+        operations=({"name": "lit", "arity": 1},)  # type: ignore[arg-type]
+    )
+    assert isinstance(s.operations[0], _Operation)
+    assert s.operations[0].name == "lit"

--- a/packages/didactic/tests/test_opaque_field.py
+++ b/packages/didactic/tests/test_opaque_field.py
@@ -1,0 +1,114 @@
+"""``dx.field(opaque=True)`` stores by-reference, skips classification.
+
+A field declared with ``opaque=True`` accepts any Python value
+without going through the type-translation pipeline. The value
+lives on the per-instance ``_opaque_storage`` side table; attribute
+access returns it identity-equal; ``with_()`` updates it without
+re-classification; ``model_dump_json`` writes ``null`` for the
+field (opaque values don't have a wire form by contract).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, cast
+
+import pytest
+
+import didactic.api as dx
+
+if TYPE_CHECKING:
+    from didactic.types._typing import FieldValue
+
+
+class _Functor(Protocol):
+    """A typeclass-shaped ABC the runtime carries by reference."""
+
+    def fmap(self, f: object, /) -> object: ...
+
+
+class _IdFunctor:
+    def fmap(self, f: object, /) -> object:
+        return f
+
+
+class _Handler(dx.Model):
+    target: _Functor = dx.field(opaque=True)
+    name: str = "anon"
+
+
+def test_opaque_field_accepts_any_python_object() -> None:
+    f = _IdFunctor()
+    h = _Handler(target=f, name="h1")
+    assert h.target is f
+    assert h.name == "h1"
+
+
+def test_opaque_field_preserves_identity_through_with_() -> None:
+    f1 = _IdFunctor()
+    f2 = _IdFunctor()
+    h = _Handler(target=f1)
+    h2 = h.with_(target=cast("FieldValue", f2))
+    assert h.target is f1
+    assert h2.target is f2
+    assert h is not h2
+
+
+def test_opaque_field_writes_null_to_json() -> None:
+    """JSON output writes ``null`` for opaque fields by contract.
+
+    Opaque values don't have a wire form; ``model_dump_json`` writes
+    ``null`` so the surrounding payload is still valid JSON. Callers
+    that want a real serialisation path use a regular field type.
+    """
+    h = _Handler(target=_IdFunctor(), name="h1")
+    payload = h.model_dump_json()
+    assert '"target": null' in payload
+    assert '"name": "h1"' in payload
+
+
+def test_opaque_field_default() -> None:
+    """Defaults work for opaque fields."""
+
+    class _M(dx.Model):
+        cb: object = dx.field(default=None, opaque=True)
+
+    m = _M()
+    assert m.cb is None
+
+    def callable_ref(x: object) -> object:
+        return x
+
+    m2 = _M(cb=callable_ref)
+    assert m2.cb is callable_ref
+
+
+def test_opaque_field_default_factory() -> None:
+    sentinel: list[int] = []
+
+    class _M(dx.Model):
+        cb: list[int] = dx.field(default_factory=lambda: sentinel, opaque=True)
+
+    m = _M()
+    assert m.cb is sentinel
+
+
+def test_opaque_field_with_unknown_kwarg_still_rejects() -> None:
+    """The opaque path doesn't loosen the unknown-field check."""
+    with pytest.raises(dx.ValidationError):
+        _Handler(target=_IdFunctor(), bogus=1)  # type: ignore[call-arg]
+
+
+def test_opaque_field_required_when_no_default() -> None:
+    """An opaque field without a default is still required."""
+    with pytest.raises(dx.ValidationError) as exc:
+        _Handler()  # type: ignore[call-arg]
+    types = {e.type for e in exc.value.entries}
+    assert "missing_required" in types
+
+
+def test_opaque_field_repr_renders_python_repr() -> None:
+    f = _IdFunctor()
+    h = _Handler(target=f)
+    out = repr(h)
+    assert "target=" in out
+    assert "anon" in out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,12 @@ dev = [
     "ruff>=0.8",
     "pyright>=1.1.388",
     "mypy>=1.13",
-    "mkdocs-material>=9.5",
+    "mkdocs>=1.6",
+    "mkdocs-cinder>=1.2",
     "mkdocstrings[python]>=0.27",
     "mkdocs-autorefs>=1.2",
+    "pymdown-extensions>=10.7",
+    "pygments>=2.18",
     "griffe>=1.5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -46,78 +46,6 @@ wheels = [
 ]
 
 [[package]]
-name = "babel"
-version = "2.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backrefs"
-version = "7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
-    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2026.4.22"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
-    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
-    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
-    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
-    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
-    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -179,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -194,7 +122,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -211,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -226,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -253,10 +181,13 @@ source = { virtual = "." }
 dev = [
     { name = "griffe" },
     { name = "hypothesis" },
+    { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
-    { name = "mkdocs-material" },
+    { name = "mkdocs-cinder" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -269,10 +200,13 @@ dev = [
 dev = [
     { name = "griffe", specifier = ">=1.5" },
     { name = "hypothesis", specifier = ">=6.115" },
+    { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-autorefs", specifier = ">=1.2" },
-    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-cinder", specifier = ">=1.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },
+    { name = "pygments", specifier = ">=2.18" },
+    { name = "pymdown-extensions", specifier = ">=10.7" },
     { name = "pyright", specifier = ">=1.1.388" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -505,6 +439,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-cinder"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c2/bf779196d7c6be5273ebd214a85bb2fa37f95ec356f11b01527c848039cb/mkdocs-cinder-1.2.0.tar.gz", hash = "sha256:2e23e940792d858347553bf029770b52ecfe10ce2707d5cc7387a822f0a025d2", size = 247582, upload-time = "2020-10-26T22:31:44.094Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/23/d36947b446312796db20668f0e389ba73e8df53f2ebb0cb9e729ef92873b/mkdocs_cinder-1.2.0-py3-none-any.whl", hash = "sha256:0615bb1c7bda0d06379c281a8d19a2c1499179c01805c9fff9208ab13af14cbe", size = 276105, upload-time = "2020-10-26T22:31:42.661Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -516,37 +459,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
-]
-
-[[package]]
-name = "mkdocs-material"
-version = "9.7.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel" },
-    { name = "backrefs" },
-    { name = "colorama" },
-    { name = "jinja2" },
-    { name = "markdown" },
-    { name = "mkdocs" },
-    { name = "mkdocs-material-extensions" },
-    { name = "paginate" },
-    { name = "pygments" },
-    { name = "pymdown-extensions" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
-]
-
-[[package]]
-name = "mkdocs-material-extensions"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -639,15 +551,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "paginate"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]
@@ -861,21 +764,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.33.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -949,15 +837,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two field-type relaxations and a docs-theme swap, bundled into one v0.7.0:

- **#38**: ``tuple[Model, ...]`` (and ``dict[str, Model]``, plain ``inner: Model``) classifies any ``dx.Model`` subclass used directly as a field type, routing through the same Embed-shaped translation that ``Embed[T]`` would have built. Closes the boilerplate where heterogeneous record tuples needed a single-variant ``TaggedUnion`` wrapper.
- **#39**: ``dx.field(opaque=True)`` declares a field that holds any Python value by reference and skips the type-classification pipeline. Useful for runtime-only handles (typeclass instances, callbacks, foreign objects).
- **Docs theme**: switches to cinder; the previous Material configuration and the `NO_MKDOCS_2_WARNING` workaround are removed from `mkdocs.yml`, the three workflows, and the README.

## Changes

- `packages/didactic/src/didactic/types/_types.py` -- new `_is_bare_model_field_target` helper and `_bare_model_translation` that delegates to `_embed_translation` (with a synthesised `EmbedSentinel`); rejects `Model`, `TaggedUnion`, and any TaggedUnion subclass so the discriminated path stays in charge of those. New `make_opaque_translation()` returns a placeholder TypeTranslation whose encode/decode/from_json all raise with a clear message.
- `packages/didactic/src/didactic/fields/_fields.py` -- `Field` and `field()` accept `opaque: bool = False`; `FieldSpec` carries `is_opaque: bool`.
- `packages/didactic/src/didactic/models/_meta.py` -- `_build_field_spec` short-circuits opaque fields with `make_opaque_translation()` and copies through every `Field` attribute.
- `packages/didactic/src/didactic/models/_model.py` -- `Model.__init__` populates a per-instance `_opaque_storage` side table for opaque fields and stamps a `"null"` placeholder in the encoded `_storage`. `__getattr__`, `with_(...)`, `from_storage_dict`, `__setstate__`, `model_dump`, and `__repr__` all consult `_opaque_storage` for opaque fields. `__slots__` adds `_opaque_storage`.
- `packages/didactic/tests/test_bare_model_field.py` (new, 5 tests).
- `packages/didactic/tests/test_opaque_field.py` (new, 8 tests).
- `mkdocs.yml` -- swaps Material for cinder; markdown extensions and mkdocstrings handler config carried forward.
- `docs/css/pygments.css`, `docs/css/custom.css` -- new; pygments token colours on dark code blocks plus mkdocstrings layout.
- `.github/workflows/{ci,docs,release}.yml`, `README.md` -- drop the `NO_MKDOCS_2_WARNING` env var.
- `pyproject.toml` -- drops `mkdocs-material`, adds `mkdocs-cinder`, `mkdocs`, `pymdown-extensions`, `pygments`.
- `CHANGELOG.md` -- `[0.7.0] - 2026-05-07` entry.
- All four packages bumped to 0.7.0.

## Tests

632 tests pass (13 new). Coverage:

- **Bare Model**: tuple of bare Model constructs and JSON-round-trips, bare-Model scalar field, `dict[str, Model]` round-trip, dict-input on construction.
- **Opaque**: accepts any Python object, identity preserved through `with_(...)`, JSON writes `null`, default value, default factory, unknown-kwarg still rejected, no default still required, repr renders Python repr.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest -ra` (632 passed)
- [x] `uv run mkdocs build --strict` (0 warnings; the cinder theme doesn't print the marketing banner that required the workaround)

## Compatibility

- **Backwards-compatible additions on the field-type axes.** Bare Model classification only fires when the type isn't already routed to the discriminated path; existing `Embed[Model]` annotations stay on the explicit-Embed translation. The `opaque` flag defaults to `False`, so unflagged fields are unchanged.
- **Theme swap is documentation-only**; no runtime code path touches Material assets.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[0.7.0]`.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #38.
Closes #39.