### PR TITLE
fix: opaque field model_validate_json round-trip (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-07
+
+### Fixed
+
+- ``model_validate_json`` no longer crashes for Models that carry an
+  opaque field. The ``null`` placeholder ``model_dump_json`` writes
+  is dropped during JSON-payload conversion (the opaque
+  translation's ``from_json`` would otherwise raise, by design); the
+  field falls back to its declared default. A required opaque field
+  with no default surfaces a clean ``missing_required``
+  ``ValidationError`` on round-trip instead of a bare ``TypeError``.
+  ``docs/guide/fields.md`` updated to spell out this behaviour
+  precisely.
+
 ## [0.7.0] - 2026-05-07
 
 ### Added

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -116,9 +116,12 @@ classify. The contract is explicit:
 
 - Construction accepts any Python value; no type check is applied.
 - Attribute access and `with_(...)` preserve identity.
-- `model_dump_json` writes `null` for opaque fields, and
-  `model_validate_json` does *not* reconstruct the value: opaque
-  fields don't have a wire form.
+- `model_dump_json` writes `null` for opaque fields. Opaque fields
+  don't have a wire form, so `model_validate_json` *drops the
+  serialised placeholder* and falls back to the field's default. A
+  required opaque field (no default) round-trips through JSON as a
+  `missing_required` `ValidationError`; an opaque field with a
+  default reconstructs as the default value.
 - Defaults work normally: `default=` for a static value,
   `default_factory=` for a per-instance default.
 

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.0"
+version = "0.7.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.0"
+version = "0.7.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.0"
+version = "0.7.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.0"
+version = "0.7.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -69,7 +69,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -1119,6 +1119,15 @@ def _from_json_payload(
             # unknown fields fall through; the Model __init__ will reject them
             out[fname] = raw
             continue
+        if spec.is_opaque:
+            # Opaque fields don't have a wire form. The serialised
+            # payload's ``null`` placeholder is dropped here so
+            # construction falls back to the field's default (or
+            # surfaces a ``missing_required`` error if there is no
+            # default). Routing the placeholder through the opaque
+            # translation's ``from_json`` would raise -- by design it
+            # refuses to fabricate a value out of thin air.
+            continue
         out[fname] = spec.translation.from_json(raw)
     return out
 

--- a/packages/didactic/tests/test_opaque_field.py
+++ b/packages/didactic/tests/test_opaque_field.py
@@ -66,6 +66,33 @@ def test_opaque_field_writes_null_to_json() -> None:
     assert '"name": "h1"' in payload
 
 
+class _HandlerWithDefault(dx.Model):
+    target: object = dx.field(default=None, opaque=True)
+    name: str = "anon"
+
+
+def test_opaque_field_validate_json_falls_back_to_default() -> None:
+    """``model_validate_json`` drops the ``null`` placeholder.
+
+    Opaque fields don't reconstruct from the wire form; the placeholder
+    is ignored and the field falls back to its declared default. The
+    non-opaque sibling fields round-trip normally.
+    """
+    h = _HandlerWithDefault(target=_IdFunctor(), name="h1")
+    rt = _HandlerWithDefault.model_validate_json(h.model_dump_json())
+    assert rt.name == "h1"
+    assert rt.target is None
+
+
+def test_opaque_field_validate_json_required_without_default_errors() -> None:
+    """A required opaque field surfaces as ``missing_required`` on round-trip."""
+    h = _Handler(target=_IdFunctor(), name="h1")
+    with pytest.raises(dx.ValidationError) as exc:
+        _Handler.model_validate_json(h.model_dump_json())
+    types = {e.type for e in exc.value.entries}
+    assert "missing_required" in types
+
+
 def test_opaque_field_default() -> None:
     """Defaults work for opaque fields."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -122,7 +122,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

The v0.7.0 ``dx.field(opaque=True)`` shipped with a documentation hallucination that turned out to be a runtime bug. ``model_dump_json`` writes ``null`` for opaque fields (the documented contract), but ``model_validate_json`` then routed that ``null`` through the opaque translation's ``from_json`` -- which raises ``TypeError`` by design. So any Model carrying an opaque field crashed on JSON round-trip, even for the non-opaque sibling fields. The doc claim that ``model_validate_json`` "does not reconstruct the value" was wrong; the actual behaviour was a hard ``TypeError``.

## Motivation

Surfaced auditing the new v0.7.0 docs against the runtime. The doc made a contract promise the runtime didn't keep.

## Changes

- ``packages/didactic/src/didactic/models/_model.py`` -- in ``_from_json_payload``, when the field's spec is opaque, drop the JSON-payload entry entirely. Construction sees no kwarg for that field and falls back to the field's default (or surfaces a clean ``missing_required`` ``ValidationError`` if there is none). The opaque translation's ``from_json`` keeps its defensive raise for any caller that bypasses ``_from_json_payload`` and reaches it directly -- the contract "opaque values cannot be fabricated from a wire form" still holds at that layer.
- ``packages/didactic/tests/test_opaque_field.py`` -- two new tests covering the fixed round-trip behaviour for both the with-default and required-no-default cases.
- ``docs/guide/fields.md`` -- replaces the hallucinated bullet with a precise description: ``model_dump_json`` writes ``null``, ``model_validate_json`` drops the placeholder and falls back to the default; required-no-default round-trips as ``missing_required``.
- ``CHANGELOG.md`` -- ``[0.7.1] - 2026-05-07`` entry.
- All four packages bumped to 0.7.1.

## Tests

634 tests pass (2 new). Coverage:

- ``model_validate_json`` on a Model with a defaulted opaque field reconstructs the non-opaque siblings normally; the opaque field resets to its default.
- A required opaque field with no default surfaces as ``missing_required`` on round-trip (rather than a bare ``TypeError``).

## Local CI

- [x] ``uv run ruff format --check``
- [x] ``uv run ruff check``
- [x] ``uv run pyright`` (0 errors)
- [x] ``uv run pytest -ra`` (634 passed)
- [x] ``uv run mkdocs build --strict`` (0 warnings)

## Compatibility

- **Backwards-compatible bug fix.** Code that previously crashed (any Model with an opaque field whose JSON output was round-tripped) now reconstructs cleanly. Code that already worked (Models without opaque fields, opaque fields constructed by hand, ``model_validate(dict)`` with explicit values) behaves identically.

## Changelog

- [x] Added a ``CHANGELOG.md`` entry under ``[0.7.1]``.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.