### PR TITLE
chore: bump panproto to 0.48.3 (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-19
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.43.1`` to ``0.48.3``.
+  The bump pulls in the ``panproto-parse`` ``emit_pretty`` fixes that
+  affect ``didactic.codegen.source.emit_pretty`` directly: every
+  iteration of ``FIELD(REPEAT(...))`` and
+  ``FIELD(SEQ(SYMBOL, REPEAT(SEQ(',', SYMBOL))))`` is now rendered
+  (the prior wheel dropped all but the first), abstract-schema edge
+  order is preserved through ``pretty_with_protocol`` (children of
+  the same parent no longer re-fuse by kind), and indent-based
+  grammars open and close indent scopes on ``_indent`` / ``_dedent``
+  external tokens. A regression test in ``tests/test_codegen.py``
+  covers the comma-separated argument case end-to-end.
+
+### Added
+
+- ``DependentLens.from_dsl_json``, ``DependentLens.from_dsl_yaml``,
+  ``DependentLens.from_dsl_nickel``, and ``DependentLens.from_dsl_path``
+  compile a ``panproto-lens-dsl`` document into a chain. Each loader
+  takes the document source (or a path; ``from_dsl_path`` dispatches
+  on extension) plus the entry vertex of the source schema the chain
+  is being authored against.
+
 ## [0.7.1] - 2026-05-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ theory.op_count            # 3
 
 ## Install
 
-didactic targets Python 3.14 and panproto 0.43+.
+didactic targets Python 3.14 and panproto 0.48+.
 
 ```sh
 pip install didactic                # core

--- a/docs/guide/lenses.md
+++ b/docs/guide/lenses.md
@@ -104,3 +104,13 @@ OpenAPI conversion, for instance), use
 against a pair of schemas. See the
 [reference page](../reference/lens.md#didactic.api.DependentLens) for the full
 surface.
+
+A chain can be authored declaratively in the `panproto-lens-dsl`
+surface (JSON, YAML, or Nickel) and loaded through
+[`DependentLens.from_dsl_path`][didactic.api.DependentLens.from_dsl_path]
+(extension-dispatched) or the format-specific
+[`from_dsl_json`][didactic.api.DependentLens.from_dsl_json],
+[`from_dsl_yaml`][didactic.api.DependentLens.from_dsl_yaml], and
+[`from_dsl_nickel`][didactic.api.DependentLens.from_dsl_nickel]
+classmethods. Each loader takes the document source plus the entry
+vertex of the source schema the chain is anchored against.

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.1"
+version = "0.7.2"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.43.1",
+    "panproto>=0.48.3",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/lenses/_dependent_lens.py
+++ b/packages/didactic/src/didactic/lenses/_dependent_lens.py
@@ -214,6 +214,117 @@ class DependentLens:
 
         return cls(panproto.ProtolensChain.from_json(json_text))
 
+    @classmethod
+    def from_dsl_json(cls, source: str, body_vertex: str) -> DependentLens:
+        """Compile a ``panproto-lens-dsl`` JSON document into a chain.
+
+        Parameters
+        ----------
+        source
+            The JSON surface of ``panproto-lens-dsl``: a top-level
+            document with ``id`` / ``description`` / ``steps`` (and
+            optional ``constraints`` / ``hints`` / ``preferences``).
+        body_vertex
+            Entry vertex of the source schema the chain is being
+            authored against. The DSL compiler uses it to anchor the
+            per-step protolens construction.
+
+        Returns
+        -------
+        DependentLens
+            The compiled chain.
+
+        Raises
+        ------
+        panproto.LensError
+            If ``source`` is not a valid lens-DSL document.
+        """
+        import panproto  # noqa: PLC0415
+
+        return cls(panproto.ProtolensChain.from_dsl_json(source, body_vertex))
+
+    @classmethod
+    def from_dsl_yaml(cls, source: str, body_vertex: str) -> DependentLens:
+        """Compile a ``panproto-lens-dsl`` YAML document into a chain.
+
+        Parameters
+        ----------
+        source
+            The YAML surface of ``panproto-lens-dsl``.
+        body_vertex
+            Entry vertex of the source schema; see
+            [from_dsl_json][didactic.api.DependentLens.from_dsl_json].
+
+        Returns
+        -------
+        DependentLens
+            The compiled chain.
+
+        Raises
+        ------
+        panproto.LensError
+            If ``source`` is not a valid lens-DSL document.
+        """
+        import panproto  # noqa: PLC0415
+
+        return cls(panproto.ProtolensChain.from_dsl_yaml(source, body_vertex))
+
+    @classmethod
+    def from_dsl_nickel(cls, source: str, body_vertex: str) -> DependentLens:
+        """Compile a ``panproto-lens-dsl`` Nickel document into a chain.
+
+        Parameters
+        ----------
+        source
+            The Nickel surface of ``panproto-lens-dsl``.
+        body_vertex
+            Entry vertex of the source schema; see
+            [from_dsl_json][didactic.api.DependentLens.from_dsl_json].
+
+        Returns
+        -------
+        DependentLens
+            The compiled chain.
+
+        Raises
+        ------
+        panproto.LensError
+            If ``source`` is not a valid lens-DSL document.
+        """
+        import panproto  # noqa: PLC0415
+
+        return cls(panproto.ProtolensChain.from_dsl_nickel(source, body_vertex))
+
+    @classmethod
+    def from_dsl_path(cls, path: str, body_vertex: str) -> DependentLens:
+        """Compile a ``panproto-lens-dsl`` document loaded from ``path``.
+
+        Dispatches on the file extension: ``.ncl`` is parsed as
+        Nickel, ``.json`` as JSON, ``.yaml`` / ``.yml`` as YAML.
+
+        Parameters
+        ----------
+        path
+            Filesystem path to a lens-DSL document.
+        body_vertex
+            Entry vertex of the source schema; see
+            [from_dsl_json][didactic.api.DependentLens.from_dsl_json].
+
+        Returns
+        -------
+        DependentLens
+            The compiled chain.
+
+        Raises
+        ------
+        panproto.LensError
+            If the file is missing or its contents are not a valid
+            lens-DSL document.
+        """
+        import panproto  # noqa: PLC0415
+
+        return cls(panproto.ProtolensChain.from_dsl_path(path, body_vertex))
+
     # operations ----------------------------------------------------
 
     def compose(self, other: DependentLens) -> DependentLens:

--- a/packages/didactic/tests/test_codegen.py
+++ b/packages/didactic/tests/test_codegen.py
@@ -293,6 +293,22 @@ def test_source_parse_then_emit_round_trips_python() -> None:
     assert len(out) > 0
 
 
+def test_source_parse_emit_preserves_every_commasep_arg() -> None:
+    """Every comma-separated call argument survives parse / emit.
+
+    Exercises the ``FIELD(SEQ(SYMBOL, REPEAT(SEQ(',', SYMBOL))))`` path
+    that the underlying panproto emitter previously collapsed to a
+    single iteration. A regression here would emit ``f(1.0)`` for
+    ``f(1.0, 2.0, 3.0)``.
+    """
+    src = b"f(1.0, 2.0, 3.0)\n"
+    schema = dx.codegen.source.parse(src, protocol="python")
+    out = dx.codegen.source.emit(schema, protocol="python")
+    text = out.decode("utf-8")
+    for literal in ("1.0", "2.0", "3.0"):
+        assert literal in text, f"missing {literal!r} in re-emitted source {text!r}"
+
+
 def test_source_for_protocol_returns_callable() -> None:
     """``for_protocol`` returns a callable that parses bytes for the given grammar."""
     parser = dx.codegen.source.for_protocol("python")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ docstring-code-format = true
 pythonVersion = "3.14"
 pythonPlatform = "All"
 typeCheckingMode = "strict"
+# point pyright at the uv-managed venv so panproto's bundled stubs are
+# discovered without callers having to pass ``--pythonpath``. Without
+# this, every ``import panproto`` resolves to ``Unknown`` and the
+# downstream attribute types cascade into ``reportUnknownMemberType``.
+venvPath = "."
+venv = ".venv"
 include = [
     "packages/didactic/src",
     "packages/didactic-pydantic/src",

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,7 +117,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.43.1" },
+    { name = "panproto", specifier = ">=0.48.3" },
 ]
 
 [[package]]
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.43.1"
+version = "0.48.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/ac/eec19f4dcb5e427b2fdc5bb3ce5776595ef410e0322a710e119995eeb69d/panproto-0.43.1-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8bf5b163e56fa16fcec4076f4eadcbff12b837451cedf484e856296df6bbbe42", size = 7619889, upload-time = "2026-05-04T16:19:29.369Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/d0/2ecfa6598a11b41b418db2c60e41c277741f5bbf64d4ce69f1dc2915f132/panproto-0.43.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:f72f35637f8b03ec23e3654fb67d7fae3941ba9ed8414f62e179c837d35cc314", size = 7663481, upload-time = "2026-05-04T16:19:31.805Z" },
-    { url = "https://files.pythonhosted.org/packages/70/d9/981d7e469e5db55e76ccbf2174762a11919f5be8b9de322d7683ee96729c/panproto-0.43.1-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:685493a153ce957f9ec9e0d780d0c8c50e6c72ad92dc983e60dff47e26472903", size = 8218401, upload-time = "2026-05-04T16:19:34.123Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/13/caf939d7beec771e6ce4fd87120bfeb85ffb359aec628fd847125b9ff21d/panproto-0.43.1-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8090dd35669e4815e45c3ac4963fd621cdfeaf6250ea887c8edf2e7302918c5d", size = 8481747, upload-time = "2026-05-04T16:19:35.949Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/31/e560ecaa87f9a1c5e5d24a0fa31da1f227190868cccb98fcab294649ccec/panproto-0.43.1-cp313-abi3-win_amd64.whl", hash = "sha256:726d4754cc599d141a4f22f8be5fed64bc1023b3bcb0235e60e65daba4bb5ba4", size = 6827663, upload-time = "2026-05-04T16:19:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/be/76f4845c73918e5f2a9f89b90de9981f12b1f933dc2fb4c269ac73de1367/panproto-0.48.3-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9ed812279153faf3aa6b51ee85f2977b95b4e277c7209490926259a63884ebf3", size = 11657014, upload-time = "2026-05-19T13:12:44.664Z" },
+    { url = "https://files.pythonhosted.org/packages/10/86/4cd21a9fb896ede21d406f8fdfba4711927e7896416a188ea0658fabf8c6/panproto-0.48.3-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:f3aa3b4510fcb7382f8624332973c3b451a13eaddf9424301a602a4754fa85fe", size = 11417381, upload-time = "2026-05-19T13:12:47.587Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ec/414adf710254b8668c6f636a5e4f72bb395566f2faed98ab150f05ba10fc/panproto-0.48.3-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:52e011cdec44b49c17eee1bb4aa831bd1e9efc465330884b83da4853b11bf9cd", size = 11959273, upload-time = "2026-05-19T13:12:49.9Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/3b7838529917a76398c27b3efb2ebc44d51ee09bc01cd5ef698125b86cf1/panproto-0.48.3-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:eaf6cb330913bbf95551464285cfad3789d6dd859661ceb35667d369b6107098", size = 12529137, upload-time = "2026-05-19T13:12:52.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3c/70067d0350c7f3f30e371836462ecd2c46918320310b6eecf38f5e533d3c/panproto-0.48.3-cp313-abi3-win_amd64.whl", hash = "sha256:e01f5fbd53f08df041d3cbbdb76df52ee0100210097e3cf5e145697417e50464", size = 11595610, upload-time = "2026-05-19T13:12:54.54Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the `panproto` floor from `0.43.1` to `0.48.3`, surfaces the new
lens-DSL loaders as `DependentLens.from_dsl_{json,yaml,nickel,path}`,
and points pyright at the uv-managed venv so panproto / pydantic /
fastapi stubs are actually discovered. Releases didactic `0.7.2`.

## Motivation

panproto cut six minor / patch releases between `0.43.1` and `0.48.3`.
Three of them (`0.48.1` / `0.48.2` / `0.48.3`) fix regressions in
`panproto-parse::emit_pretty` that flow straight through
`didactic.codegen.source.emit_pretty`:

- `FIELD(REPEAT(...))` previously dropped all iterations past the first
  (so a Python `program` with N statements re-emitted as one).
- `FIELD(SEQ(SYMBOL, REPEAT(SEQ(',', SYMBOL))))` (the `commaSep1`
  shape) had the same bug; `f(1.0, 2.0, 3.0)` re-emitted as `f(1.0)`.
- Abstract-schema children of the same parent re-fused by kind under
  `REPEAT(CHOICE(...))`; `''c d 4 4` came out of a lilypond
  `expression_block` instead of the original interleaving.
- Indent-based grammars (Python, YAML) needed `_indent` / `_dedent`
  external tokens to drive `Output::indent_open` / `indent_close`;
  without it the emitted source was structurally well-formed but
  unparseable.

`0.47.0` added `ProtolensChain.from_dsl_{json,yaml,nickel,path}` for
loading declarative chain definitions; this PR wraps those at the
didactic surface.

## Changes

- `packages/didactic/pyproject.toml` — bump `panproto>=0.43.1` →
  `panproto>=0.48.3`; bump didactic version to `0.7.2`.
- `packages/didactic/src/didactic/lenses/_dependent_lens.py` — add
  `from_dsl_json`, `from_dsl_yaml`, `from_dsl_nickel`, and
  `from_dsl_path` classmethods on `DependentLens`. Each takes the
  document source (or a path; `from_dsl_path` dispatches on
  extension) plus the entry vertex of the source schema the chain is
  anchored against.
- `pyproject.toml` — add `venvPath = "."` / `venv = ".venv"` under
  `[tool.pyright]` so the bundled stubs in `.venv/lib/python3.14/
  site-packages/panproto/_native.pyi` are picked up automatically.
  Without this `import panproto` resolved to `Unknown` and the
  downstream attribute types cascaded into hundreds of
  `reportUnknownMemberType` errors that were masking real ones.
- `docs/guide/lenses.md` — document the new DSL loaders.
- `README.md` — bump the install note from `panproto 0.43+` to
  `panproto 0.48+`.
- `CHANGELOG.md` — `0.7.2` entry under `Changed` and `Added`.
- `packages/didactic/tests/test_codegen.py` — new
  `test_source_parse_emit_preserves_every_commasep_arg` regression
  test exercises the `f(1.0, 2.0, 3.0)` reproducer end-to-end through
  `dx.codegen.source.parse` / `emit`.

## Tests

- `test_source_parse_emit_preserves_every_commasep_arg` covers the
  `commaSep1` regression directly through the source-emission path.
- `pytest -q` is green (635 passed) on Python 3.14 with the
  `panproto==0.48.3` wheel installed.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`

## Compatibility

- **Backwards-compatible addition** — the four `from_dsl_*`
  classmethods are net-new; the `emit_pretty` behaviour change is a
  bug fix (the prior output was structurally wrong for repeated-field
  grammars). The `panproto` floor bump is the only thing existing
  callers will notice, and only if they had `panproto<0.48.3` pinned
  in a constraint file.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[Unreleased]` / `0.7.2`.
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.
  The opposite, actually — wiring `venvPath` into the pyright config
  eliminates the ~500-error baseline that was masking the genuine
  diagnostics.

## Linked issues

None.