### PR TITLE
feat(lenses): wrap hom search; bump panproto to 0.52.0 (v0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-07
+
+### Added
+
+- ``find_correspondences``, ``best_correspondence``, and the
+  ``Correspondence`` record wrap panproto's hom search
+  (``find_morphisms`` / ``find_best_morphism``). Given two panproto
+  Schemas, the search enumerates structure-preserving vertex maps,
+  scored by alignment quality, with ``anchors`` to pin known pairings
+  and ``monic`` / ``epic`` / ``iso`` to constrain the map's shape. A
+  discovered ``Correspondence.vertex_map`` has exactly the
+  ``dict[str, str]`` shape that
+  ``DependentLens.auto_generate_with_hints`` takes as ``hints``, so
+  the two compose into a discover-then-derive pipeline (documented in
+  the lenses guide). The search is informative on multi-vertex
+  schemas (hand-built protocol schemas, parse-recovered source
+  schemas); the single-vertex schemas didactic builds from Model
+  classes degenerate to the root pairing.
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.48.3`` to ``0.52.0``.
+  The bump pulls in, with direct effect on didactic's surface:
+
+  - The hom-search bindings (``find_morphisms``,
+    ``find_best_morphism``, ``TheoryMorphism``, ``SchemaMorphism``,
+    ``FoundMorphism``) that back the new correspondence API.
+  - The ``emit_pretty`` rewrite (grammar-derived token roles, role-pair
+    spacing, structural bracket detection) and the emit-coverage sweep
+    that corpus-verifies the emit fixed-point law
+    (``emit(parse(emit(s))) == emit(s)``), covering every grammar the
+    ``panproto`` wheel ships. This is the engine behind
+    ``didactic.codegen.source.emit_pretty`` and ``Model.emit_as``.
+  - ``get_builtin_protocol`` resolving tree-sitter grammar protocols
+    (``get_builtin_protocol("python")`` succeeds instead of raising
+    ``KeyError``).
+  - ``IdGenerator`` disambiguation of repeated names at the same
+    scope, which unblocks parsing any Python source that uses
+    ``@typing.overload`` through ``didactic.codegen.source.parse``.
+  - Resynced ``_native.pyi`` stubs. didactic's typing follows:
+    ``DependentLens.auto_generate_with_hints`` declares
+    ``hints: dict[str, str]`` (was ``object``), and the
+    ``TheorySpec`` handoff to ``panproto.create_theory`` narrows
+    through a documented boundary cast (a ``TypedDict`` is assignable
+    to ``Mapping[str, object]`` and to no narrower mapping, while the
+    resynced stub takes ``Mapping[str, JsonValue]``).
+
+### Fixed
+
+- ``__version__`` strings match the released distribution version
+  across all four packages. The core ``didactic.api.__version__`` and
+  the three sibling ``__init__`` modules lagged behind their
+  ``pyproject.toml`` versions, so ``didactic version`` under-reported.
+
 ## [0.7.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ theory.op_count            # 3
 
 ## Install
 
-didactic targets Python 3.14 and panproto 0.48+.
+didactic targets Python 3.14 and panproto 0.52+.
 
 ```sh
 pip install didactic                # core

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -35,7 +35,8 @@ schema VCS implementations, and the protocol codecs.
   (Avro, OpenAPI, FHIR, Protobuf, BSON, CDDL, Parquet, ...).
 - `panproto.AstParserRegistry`: tree-sitter-backed parsers for many
   programming languages, with an emitter that walks `grammar.json`
-  productions to produce syntactically valid source de novo.
+  productions to produce source de novo, round-trip-checked against
+  each grammar's upstream corpus in panproto's test suite.
 - Schema diff, breaking-change classification, and migration
   synthesis.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -110,6 +110,6 @@ Prints didactic's version followed by panproto's:
 
 ```bash
 didactic version
-# didactic 0.0.1.dev0
-# panproto 0.43.0
+# didactic 0.7.3
+# panproto 0.52.0
 ```

--- a/docs/guide/lenses.md
+++ b/docs/guide/lenses.md
@@ -114,3 +114,36 @@ surface (JSON, YAML, or Nickel) and loaded through
 [`from_dsl_nickel`][didactic.api.DependentLens.from_dsl_nickel]
 classmethods. Each loader takes the document source plus the entry
 vertex of the source schema the chain is anchored against.
+
+## Correspondence discovery
+
+When you have two concrete schemas and don't yet know how their
+vertices line up, [find_correspondences][didactic.api.find_correspondences]
+enumerates the structure-preserving vertex maps between them via
+panproto's hom search, scored by alignment quality;
+[best_correspondence][didactic.api.best_correspondence] returns just the
+top match. The discovered
+[Correspondence.vertex_map][didactic.api.Correspondence] feeds
+[DependentLens.auto_generate_with_hints][didactic.api.DependentLens.auto_generate_with_hints]
+directly, giving a discover-then-derive pipeline:
+
+```python
+import didactic.api as dx
+
+best = dx.best_correspondence(src_schema, tgt_schema)
+if best is not None and best.quality >= 0.8:
+    chain = dx.DependentLens.auto_generate_with_hints(
+        src_schema,
+        tgt_schema,
+        protocol,
+        best.vertex_map,
+    )
+```
+
+Known pairings can be pinned with `anchors`; injective, surjective,
+or bijective maps can be required with `monic`, `epic`, and `iso`.
+Note that the schemas didactic builds from Model classes are
+single-vertex (their structure lives in the Theory), so the search is
+informative on multi-vertex schemas: protocol schemas built by hand
+and schemas recovered by
+[didactic.codegen.source.parse][didactic.codegen.source.parse].

--- a/docs/project/stability.md
+++ b/docs/project/stability.md
@@ -40,7 +40,7 @@ each is documented in the [Changelog](changelog.md).
 
 ## panproto compatibility
 
-didactic pins panproto via a `>=` floor (currently `panproto>=0.43`).
+didactic pins panproto via a `>=` floor (currently `panproto>=0.52`).
 panproto's wire format may change between minor releases; didactic
 absorbs the difference internally so `import didactic` keeps working
 across panproto upgrades within the supported range.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,7 +20,8 @@ parameter list.
 ## Schema evolution
 
 - [Lens](lens.md): `Lens`, `Iso`, `Mapping`, `DependentLens`,
-  `lens` decorator.
+  `lens` decorator, `Correspondence`, `find_correspondences`,
+  `best_correspondence`.
 - [Migrations](migrations.md): `register_migration`, `migrate`,
   `save_registry`, `load_registry`.
 - [Schema diff](diff.md): `diff`, `classify_change`,

--- a/docs/reference/lens.md
+++ b/docs/reference/lens.md
@@ -9,3 +9,9 @@
 ::: didactic.api.DependentLens
 
 ::: didactic.api.lens
+
+::: didactic.api.Correspondence
+
+::: didactic.api.find_correspondences
+
+::: didactic.api.best_correspondence

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.2"
+version = "0.7.3"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.2"
+version = "0.7.3"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.2"
+version = "0.7.3"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/README.md
+++ b/packages/didactic/README.md
@@ -19,7 +19,7 @@ contribute submodules under `didactic.<name>`.
 
 ## Install
 
-didactic targets Python 3.14 and panproto 0.43+.
+didactic targets Python 3.14 and panproto 0.52+.
 
 ```sh
 pip install didactic

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.2"
+version = "0.7.3"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.48.3",
+    "panproto>=0.52.0",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -54,6 +54,11 @@ from didactic.fields._validators import (
 from didactic.lenses import _testing as testing
 from didactic.lenses._dependent_lens import DependentLens
 from didactic.lenses._lens import Iso, Lens, Mapping, lens
+from didactic.lenses._morphisms import (
+    Correspondence,
+    best_correspondence,
+    find_correspondences,
+)
 from didactic.migrations._diff import classify_change, diff, is_breaking_change
 from didactic.migrations._migrations import (
     load_registry,
@@ -69,7 +74,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator
@@ -81,6 +86,7 @@ __all__ = [
     "Axiom",
     "Backref",
     "BaseModel",
+    "Correspondence",
     "DependentLens",
     "Embed",
     "ExtraPolicy",
@@ -103,6 +109,7 @@ __all__ = [
     "ValidationErrorEntry",
     "__version__",
     "axiom",
+    "best_correspondence",
     "classify_change",
     "codegen",
     "computed",
@@ -110,6 +117,7 @@ __all__ = [
     "diff",
     "embed_schema_uri",
     "field",
+    "find_correspondences",
     "is_breaking_change",
     "lens",
     "load_registry",

--- a/packages/didactic/src/didactic/codegen/source.py
+++ b/packages/didactic/src/didactic/codegen/source.py
@@ -4,8 +4,11 @@ For every tree-sitter grammar panproto bundles, didactic can:
 
 - **De-novo emit** a [Model][didactic.api.Model] class as fresh source via
   [emit_pretty][didactic.codegen.source.emit_pretty]. Walks the
-  grammar's production rules; output is syntactically valid for any
-  grammar that ships a ``grammar.json``.
+  grammar's production rules; spacing and indentation derive from
+  grammar-classified token roles. Emit round-trips are checked
+  against each grammar's upstream corpus in panproto's test suite.
+  Use [available_targets][didactic.codegen.source.available_targets]
+  to enumerate what the running build supports.
 - **Edit-pipeline emit**: parse real source, transform the schema,
   re-emit the bytes. Uses [emit][didactic.codegen.source.emit].
 - **Parse** source bytes into a panproto Schema for inspection.

--- a/packages/didactic/src/didactic/lenses/__init__.py
+++ b/packages/didactic/src/didactic/lenses/__init__.py
@@ -4,12 +4,20 @@ from didactic.lenses import _testing as testing
 from didactic.lenses._dependent_lens import DependentLens
 from didactic.lenses._lens import Iso, Lens, Mapping, identity
 from didactic.lenses._lens import lens as lens
+from didactic.lenses._morphisms import (
+    Correspondence,
+    best_correspondence,
+    find_correspondences,
+)
 
 __all__ = [
+    "Correspondence",
     "DependentLens",
     "Iso",
     "Lens",
     "Mapping",
+    "best_correspondence",
+    "find_correspondences",
     "identity",
     "lens",
     "testing",

--- a/packages/didactic/src/didactic/lenses/_dependent_lens.py
+++ b/packages/didactic/src/didactic/lenses/_dependent_lens.py
@@ -146,7 +146,7 @@ class DependentLens:
         src_schema: panproto.Schema,
         tgt_schema: panproto.Schema,
         protocol: panproto.Protocol,
-        hints: object,
+        hints: dict[str, str],
         *,
         stringency: str | None = None,
     ) -> DependentLens:
@@ -161,8 +161,10 @@ class DependentLens:
         protocol
             The panproto protocol both schemas conform to.
         hints
-            Vertex-correspondence hints. Their exact shape is
-            panproto-defined.
+            Vertex-correspondence hints mapping source-schema vertex
+            IDs to target-schema vertex IDs. A discovered
+            [Correspondence][didactic.api.Correspondence] supplies this
+            shape via its ``vertex_map``.
         stringency
             Optional stringency hint. ``None`` uses panproto's default.
 

--- a/packages/didactic/src/didactic/lenses/_morphisms.py
+++ b/packages/didactic/src/didactic/lenses/_morphisms.py
@@ -1,0 +1,200 @@
+"""Vertex-correspondence discovery via panproto's hom search.
+
+Given two panproto Schemas, panproto can enumerate the structure-
+preserving maps (schema morphisms) between them and score each one.
+didactic wraps that search as
+[find_correspondences][didactic.api.find_correspondences] and
+[best_correspondence][didactic.api.best_correspondence], returning
+plain [Correspondence][didactic.api.Correspondence] records.
+
+The discovered ``vertex_map`` has exactly the shape that
+[DependentLens.auto_generate_with_hints][didactic.api.DependentLens.auto_generate_with_hints]
+takes as ``hints``, so the two compose into a discover-then-derive
+pipeline: search for the best correspondence, then derive a chain
+that respects it.
+
+Examples
+--------
+>>> import didactic.api as dx
+>>> import panproto
+>>>
+>>> proto = panproto.get_builtin_protocol("openapi")
+>>> # ... build src_schema and tgt_schema via proto.schema() ...
+>>>
+>>> best = dx.best_correspondence(src_schema, tgt_schema)  # doctest: +SKIP
+>>> best.vertex_map  # doctest: +SKIP
+{'post:body.text': 'post:body.content', ...}
+>>> chain = dx.DependentLens.auto_generate_with_hints(  # doctest: +SKIP
+...     src_schema,
+...     tgt_schema,
+...     proto,
+...     best.vertex_map,
+... )
+
+See Also
+--------
+didactic.lenses._dependent_lens : the hint-consuming chain derivation.
+panproto.find_morphisms : the runtime search.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import panproto
+
+
+@dataclass(frozen=True, slots=True)
+class Correspondence:
+    """One discovered schema morphism, scored.
+
+    Parameters
+    ----------
+    vertex_map
+        Mapping from source-schema vertex IDs to target-schema vertex
+        IDs. Feed directly as the ``hints`` argument of
+        [DependentLens.auto_generate_with_hints][didactic.api.DependentLens.auto_generate_with_hints].
+    quality
+        Alignment quality in ``[0.0, 1.0]``. Higher is better.
+    """
+
+    vertex_map: dict[str, str]
+    quality: float
+
+
+def find_correspondences(
+    src_schema: panproto.Schema,
+    tgt_schema: panproto.Schema,
+    *,
+    anchors: dict[str, str] | None = None,
+    monic: bool = False,
+    epic: bool = False,
+    iso: bool = False,
+    max_results: int = 0,
+    relax_edge_name_pruning: bool = False,
+) -> list[Correspondence]:
+    """Enumerate scored vertex correspondences between two schemas.
+
+    Parameters
+    ----------
+    src_schema
+        Source schema.
+    tgt_schema
+        Target schema.
+    anchors
+        Vertex pairs (source ID to target ID) the search must respect.
+        Use to pin known correspondences and let the search fill in
+        the rest.
+    monic
+        Require the morphism to be injective on vertices (no two
+        source vertices map to the same target vertex).
+    epic
+        Require the morphism to be surjective on vertices (every
+        target vertex is hit).
+    iso
+        Require a bijection. Implies ``monic`` and ``epic``.
+    max_results
+        Upper bound on the number of morphisms returned. ``0`` means
+        unbounded.
+    relax_edge_name_pruning
+        Keep kind-compatible candidate targets that share no outgoing
+        edge name with the source vertex. By default the search prunes
+        such candidates for object vertices with large candidate
+        domains, which can discard a correct pairing when every child
+        was renamed. Naturality is still enforced.
+
+    Returns
+    -------
+    list of Correspondence
+        Discovered correspondences. Empty when no structure-preserving
+        map exists under the given constraints.
+
+    Notes
+    -----
+    The schemas didactic builds from Model classes are single-vertex
+    (the structure lives in the Theory), so searching between two
+    Models degenerates to the root pairing. The search is informative
+    on multi-vertex schemas: protocol schemas built by hand and
+    schemas recovered by [didactic.codegen.source.parse][].
+    """
+    import panproto  # noqa: PLC0415
+
+    found = panproto.find_morphisms(
+        src_schema,
+        tgt_schema,
+        anchors=anchors,
+        monic=monic,
+        epic=epic,
+        iso=iso,
+        max_results=max_results,
+        relax_edge_name_pruning=relax_edge_name_pruning,
+    )
+    return [
+        Correspondence(vertex_map=m.vertex_map, quality=float(m.quality)) for m in found
+    ]
+
+
+def best_correspondence(
+    src_schema: panproto.Schema,
+    tgt_schema: panproto.Schema,
+    *,
+    anchors: dict[str, str] | None = None,
+    monic: bool = False,
+    epic: bool = False,
+    iso: bool = False,
+    relax_edge_name_pruning: bool = False,
+) -> Correspondence | None:
+    """Return the highest-quality correspondence, or ``None``.
+
+    Parameters
+    ----------
+    src_schema
+        Source schema.
+    tgt_schema
+        Target schema.
+    anchors
+        Vertex pairs (source ID to target ID) the search must respect.
+    monic
+        Require injectivity on vertices.
+    epic
+        Require surjectivity on vertices.
+    iso
+        Require a bijection. Implies ``monic`` and ``epic``.
+    relax_edge_name_pruning
+        Keep kind-compatible candidate targets that share no outgoing
+        edge name with the source vertex. See
+        [find_correspondences][didactic.api.find_correspondences].
+
+    Returns
+    -------
+    Correspondence or None
+        The best-scoring correspondence, or ``None`` when no
+        structure-preserving map exists under the given constraints.
+
+    See Also
+    --------
+    find_correspondences : the full enumeration.
+    """
+    import panproto  # noqa: PLC0415
+
+    found = panproto.find_best_morphism(
+        src_schema,
+        tgt_schema,
+        anchors=anchors,
+        monic=monic,
+        epic=epic,
+        iso=iso,
+        relax_edge_name_pruning=relax_edge_name_pruning,
+    )
+    if found is None:
+        return None
+    return Correspondence(vertex_map=found.vertex_map, quality=float(found.quality))
+
+
+__all__ = [
+    "Correspondence",
+    "best_correspondence",
+    "find_correspondences",
+]

--- a/packages/didactic/src/didactic/theory/_theory.py
+++ b/packages/didactic/src/didactic/theory/_theory.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import panproto
 
     from didactic.fields._fields import FieldSpec
@@ -56,6 +58,31 @@ class TheorySpec(TypedDict):
     eqs: list[dict[str, JsonValue]]
     directed_eqs: list[dict[str, JsonValue]]
     policies: list[dict[str, JsonValue]]
+
+
+def _spec_payload(spec: TheorySpec) -> Mapping[str, JsonValue]:
+    """Narrow a ``TheorySpec`` to the mapping shape ``create_theory`` takes.
+
+    Parameters
+    ----------
+    spec
+        A spec dict from ``build_theory_spec``.
+
+    Returns
+    -------
+    Mapping
+        The same dict, typed as ``Mapping[str, JsonValue]``.
+
+    Notes
+    -----
+    The typing spec makes a ``TypedDict`` assignable to
+    ``Mapping[str, object]`` and to no mapping with a narrower value
+    type, so handing a ``TheorySpec`` to ``panproto.create_theory``
+    (whose parameter is ``Mapping[str, JsonValue]``) needs a cast at
+    the boundary. Every ``TheorySpec`` field type is a ``JsonValue``,
+    so the cast is sound.
+    """
+    return cast("Mapping[str, JsonValue]", spec)
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +374,7 @@ def build_theory(cls: type) -> panproto.Theory:
     if len(parents) <= 1:
         # single (or no) Model inheritance: the flat spec is correct
         spec = build_theory_spec(cls)
-        return panproto.create_theory(spec)
+        return panproto.create_theory(_spec_payload(spec))
 
     # multiple Model inheritance: compute the colimit of the parent
     # theories over their lowest common ancestor in the Model lineage
@@ -432,13 +459,15 @@ def _build_colimit_theory(cls: type, parents: list[type]) -> panproto.Theory:
     """
     import panproto  # noqa: PLC0415
 
-    accumulator = panproto.create_theory(build_theory_spec(parents[0]))
+    accumulator = panproto.create_theory(_spec_payload(build_theory_spec(parents[0])))
     accumulator_cls: type = parents[0]
 
     for parent in parents[1:]:
         ancestor = _lowest_common_model_ancestor([accumulator_cls, parent])
-        ancestor_theory = panproto.create_theory(build_theory_spec(ancestor))
-        next_theory = panproto.create_theory(build_theory_spec(parent))
+        ancestor_theory = panproto.create_theory(
+            _spec_payload(build_theory_spec(ancestor))
+        )
+        next_theory = panproto.create_theory(_spec_payload(build_theory_spec(parent)))
         accumulator = panproto.colimit_theories(
             accumulator, next_theory, ancestor_theory
         )
@@ -447,7 +476,7 @@ def _build_colimit_theory(cls: type, parents: list[type]) -> panproto.Theory:
     # finally fold in any cls-only fields by colimiting against the
     # immediate spec of cls; the shared ancestor is the accumulated
     # theory we just built
-    cls_theory = panproto.create_theory(build_theory_spec(cls))
+    cls_theory = panproto.create_theory(_spec_payload(build_theory_spec(cls)))
     return panproto.colimit_theories(accumulator, cls_theory, accumulator)
 
 

--- a/packages/didactic/tests/test_morphisms.py
+++ b/packages/didactic/tests/test_morphisms.py
@@ -1,0 +1,120 @@
+"""Tests for ``dx.find_correspondences`` / ``dx.best_correspondence``.
+
+The wrappers delegate to ``panproto.find_morphisms`` /
+``panproto.find_best_morphism``; these tests verify the didactic-side
+surface (record shape, ordering, constraint pass-through) and the
+discover-then-derive pipeline into
+``DependentLens.auto_generate_with_hints``.
+"""
+
+from __future__ import annotations
+
+import panproto
+
+import didactic.api as dx
+
+
+def _proto() -> panproto.Protocol:
+    return panproto.get_builtin_protocol("atproto")
+
+
+def _post_schema(body_field: str) -> panproto.Schema:
+    """Build a three-vertex atproto schema with one body prop."""
+    builder = _proto().schema()
+    builder.vertex("post", "record", "app.bsky.feed.post")
+    builder.vertex("post:body", "object")
+    builder.vertex(f"post:body.{body_field}", "string")
+    builder.edge("post", "post:body", "record-schema")
+    builder.edge("post:body", f"post:body.{body_field}", "prop", body_field)
+    return builder.build()
+
+
+# -- find_correspondences ----------------------------------------------
+
+
+def test_find_correspondences_returns_records() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    found = dx.find_correspondences(src, tgt)
+    assert found
+    assert all(isinstance(c, dx.Correspondence) for c in found)
+
+
+def test_find_correspondences_discovers_rename() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    found = dx.find_correspondences(src, tgt)
+    maps = [c.vertex_map for c in found]
+    assert {
+        "post": "post",
+        "post:body": "post:body",
+        "post:body.text": "post:body.content",
+    } in maps
+
+
+def test_find_correspondences_quality_in_unit_interval() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    for c in dx.find_correspondences(src, tgt):
+        assert 0.0 <= c.quality <= 1.0
+
+
+def test_find_correspondences_identical_schemas_score_higher() -> None:
+    same = dx.best_correspondence(_post_schema("text"), _post_schema("text"))
+    renamed = dx.best_correspondence(_post_schema("text"), _post_schema("content"))
+    assert same is not None
+    assert renamed is not None
+    assert same.quality >= renamed.quality
+
+
+# -- best_correspondence -----------------------------------------------
+
+
+def test_best_correspondence_matches_enumeration_maximum() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    best = dx.best_correspondence(src, tgt)
+    found = dx.find_correspondences(src, tgt)
+    assert best is not None
+    assert best.quality == max(c.quality for c in found)
+
+
+def test_best_correspondence_respects_anchors() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    best = dx.best_correspondence(src, tgt, anchors={"post": "post"})
+    assert best is not None
+    assert best.vertex_map["post"] == "post"
+
+
+# -- pipeline into DependentLens ---------------------------------------
+
+
+def test_vertex_map_feeds_auto_generate_with_hints() -> None:
+    src = _post_schema("text")
+    tgt = _post_schema("content")
+    best = dx.best_correspondence(src, tgt)
+    assert best is not None
+    chain = dx.DependentLens.auto_generate_with_hints(
+        src,
+        tgt,
+        _proto(),
+        best.vertex_map,
+    )
+    assert isinstance(chain, dx.DependentLens)
+
+
+# -- record semantics --------------------------------------------------
+
+
+def test_correspondence_is_frozen() -> None:
+    import dataclasses
+
+    c = dx.Correspondence(vertex_map={"a": "b"}, quality=0.5)
+    assert dataclasses.is_dataclass(c)
+    try:
+        c.quality = 0.9  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    msg = "Correspondence must be frozen"
+    raise AssertionError(msg)

--- a/packages/didactic/tests/test_types.py
+++ b/packages/didactic/tests/test_types.py
@@ -13,8 +13,10 @@ from annotated_types import Ge, Le, MaxLen, MinLen
 from didactic.types._types import TypeNotSupportedError, classify, unwrap_annotated
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from didactic.types._types import TypeForm
-    from didactic.types._typing import FieldValue
+    from didactic.types._typing import FieldValue, JsonValue
 
 
 def test_typing_aliases_importable_at_runtime() -> None:
@@ -649,16 +651,15 @@ def test_panproto_accepts_alias_theory_spec() -> None:
     """panproto's ``create_theory`` accepts the spec with the alias sorts.
 
     Verifies that the closed sum sort + helper sorts + constructor ops
-    deserialise into a real ``panproto.Theory`` without error. The
-    ``Theory.sorts`` attribute is a list of sort dicts at runtime
-    (the stub claims it's a method; treat as data).
+    deserialise into a real ``panproto.Theory`` without error.
     """
     import panproto
 
     from didactic.theory._theory import build_theory_spec
 
     spec = build_theory_spec(_DocWithComponent)
-    theory = panproto.create_theory(cast("dict[str, object]", spec))
-    sort_records = cast("list[dict[str, object]]", theory.sorts)
-    sort_names = {cast("str", record["name"]) for record in sort_records}
+    # a TypedDict is assignable to ``Mapping[str, object]`` and to no
+    # narrower mapping; cast to the shape ``create_theory`` takes
+    theory = panproto.create_theory(cast("Mapping[str, JsonValue]", spec))
+    sort_names = {cast("str", record["name"]) for record in theory.sorts}
     assert "_Component" in sort_names

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,12 +117,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.48.3" },
+    { name = "panproto", specifier = ">=0.52.0" },
 ]
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.48.3"
+version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/be/76f4845c73918e5f2a9f89b90de9981f12b1f933dc2fb4c269ac73de1367/panproto-0.48.3-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9ed812279153faf3aa6b51ee85f2977b95b4e277c7209490926259a63884ebf3", size = 11657014, upload-time = "2026-05-19T13:12:44.664Z" },
-    { url = "https://files.pythonhosted.org/packages/10/86/4cd21a9fb896ede21d406f8fdfba4711927e7896416a188ea0658fabf8c6/panproto-0.48.3-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:f3aa3b4510fcb7382f8624332973c3b451a13eaddf9424301a602a4754fa85fe", size = 11417381, upload-time = "2026-05-19T13:12:47.587Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ec/414adf710254b8668c6f636a5e4f72bb395566f2faed98ab150f05ba10fc/panproto-0.48.3-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:52e011cdec44b49c17eee1bb4aa831bd1e9efc465330884b83da4853b11bf9cd", size = 11959273, upload-time = "2026-05-19T13:12:49.9Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/29/3b7838529917a76398c27b3efb2ebc44d51ee09bc01cd5ef698125b86cf1/panproto-0.48.3-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:eaf6cb330913bbf95551464285cfad3789d6dd859661ceb35667d369b6107098", size = 12529137, upload-time = "2026-05-19T13:12:52.152Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3c/70067d0350c7f3f30e371836462ecd2c46918320310b6eecf38f5e533d3c/panproto-0.48.3-cp313-abi3-win_amd64.whl", hash = "sha256:e01f5fbd53f08df041d3cbbdb76df52ee0100210097e3cf5e145697417e50464", size = 11595610, upload-time = "2026-05-19T13:12:54.54Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/80/aa1b6ddf2ca42f3f76092a61b85c99507deed811d62d839d6fb4a71744ae/panproto-0.52.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:106472cd46fff89b60cc38c1ebce47d11867fd5755eff89a8e3107ea86764c28", size = 11793554, upload-time = "2026-06-05T21:45:20.775Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ac/6c4b0152ecb5a482681b3599afd7f4adf47313c55b827aac15f553ce1ed5/panproto-0.52.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:3d3ce1be771b97f56f40391c8d59121e320d8209836a06ac5dc0cd9c848bc045", size = 11536442, upload-time = "2026-06-05T21:45:23.137Z" },
+    { url = "https://files.pythonhosted.org/packages/08/df/f41bf3e26dfb357999298f96b666f79bed6261138ee36f0cdf949716bc42/panproto-0.52.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:768b878b250ad1727cbcec04b5a29c7d123854d73dff42b68651c920e0124bd1", size = 12081816, upload-time = "2026-06-05T21:45:25.563Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/87af188bca792f7361633e1425b872212aab79d252241dfa526859f5e32c/panproto-0.52.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:dfa6644aa225ebd023a24aff70cbe89477469217eb017681f8a06c1d577ee8f3", size = 12674837, upload-time = "2026-06-05T21:45:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/25/75/0d9a74d480a2b45c7147113ba58f13b2d38797f7639a0a0f286f76812209/panproto-0.52.0-cp313-abi3-win_amd64.whl", hash = "sha256:4147b878ca55a76ec0357f8a36f8e2dec22b83c9b7a3a00f76fb6a8454812a7c", size = 11746007, upload-time = "2026-06-05T21:45:29.849Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Raises the panproto floor from 0.48.3 to 0.52.0 and exposes the hom-search surface that arrived with it: `dx.find_correspondences`, `dx.best_correspondence`, and the `Correspondence` record. Bumps all four distributions to 0.7.3.

## Motivation

panproto 0.52.0 lands three release lines that matter to didactic: the hom-search/cascade Python bindings, the resynced `_native.pyi` stubs, and the `emit_pretty` rewrite with corpus-verified round-trips for every grammar the wheel ships. This PR absorbs the floor bump and percolates the new capability into didactic's lens surface.

## Changes

- `packages/didactic/src/didactic/lenses/_morphisms.py` — new module wrapping `panproto.find_morphisms` / `find_best_morphism`; `Correspondence.vertex_map` has exactly the `hints: dict[str, str]` shape that `DependentLens.auto_generate_with_hints` consumes, so the two compose into a discover-then-derive pipeline. Exported via `didactic.lenses` and `didactic.api`.
- `packages/didactic/src/didactic/lenses/_dependent_lens.py` — `auto_generate_with_hints` declares `hints: dict[str, str]` (was `object`), matching the resynced upstream stub.
- `packages/didactic/src/didactic/theory/_theory.py` — `_spec_payload` boundary helper: `create_theory` takes `Mapping[str, JsonValue]` under the resynced stubs, and a `TypedDict` is assignable to `Mapping[str, object]` and to no narrower mapping; the five call sites narrow through one documented cast.
- `packages/didactic/src/didactic/codegen/source.py` — emit docs describe the grammar-derived token-role layout and upstream corpus verification, without quantified coverage claims that drift with panproto releases.
- `packages/didactic/pyproject.toml` — `panproto>=0.52.0`; all four distributions bumped to 0.7.3 in lockstep, and the lagging `__version__` strings (core `api.py` at 0.7.1 pre-existing miss, three sibling `__init__` modules at 0.7.1) synced so `didactic version` reports correctly.
- `docs/` — lenses guide gains a "Correspondence discovery" section; reference pages updated; stale floors corrected in the stability page, CLI guide, and both READMEs.
- `CHANGELOG.md` — `[0.7.3] - 2026-06-07` entry covering the addition, the floor bump and its didactic-visible effects, and the version-string fix.

## Tests

`packages/didactic/tests/test_morphisms.py` (8 tests): record shape, rename discovery on multi-vertex atproto schemas, quality bounds and orderings, anchor pass-through, frozen-record semantics, and the end-to-end pipeline into `DependentLens.auto_generate_with_hints`. `test_types.py` drops the obsolete `Theory.sorts` stub workaround. Full suite: 643 passed.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`

## Compatibility

- **Backwards-compatible addition** — new public symbols (`Correspondence`, `find_correspondences`, `best_correspondence`) and a raised dependency floor; existing code keeps working. The `hints` parameter of `DependentLens.auto_generate_with_hints` narrows from `object` to `dict[str, str]` at the type level only; the runtime always required that shape.

## Changelog

- [x] Added a `CHANGELOG.md` entry (under `[0.7.3]`, since this PR is the version bump; a fresh `[Unreleased]` heading sits above it).

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Refs panproto/panproto#186: the upstream stub-drift report (`Instance` accessors, `diff_and_classify` arity, `ProtolensChain.instantiate`), filed as a follow-up to the 0.50.1 stub resync. The two boundary casts this PR leaves in place (`_diff.py`, `_dependent_lens.py`) can be deleted once it lands.
