### PR TITLE
chore: bump panproto to 0.52.1, drop stub workarounds (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-06-10
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.52.0`` to ``0.52.1``.
+  The release resyncs the ``_native.pyi`` stubs to the runtime
+  (``diff_and_classify`` takes a third ``protocol`` argument;
+  ``ProtolensChain.instantiate`` takes ``(schema, protocol)``;
+  ``Instance.root`` / ``node_count`` / ``arc_count`` are ``int``
+  properties and ``Instance.validate()`` returns the error list).
+  It also tightens by-construction source emit for Rust and Julia
+  (line comments no longer absorb the following items, opaque token
+  trees emit verbatim, Julia parenthesised macro calls keep their
+  arguments), which flows through
+  ``didactic.codegen.source.emit_pretty`` and ``Model.emit_as``.
+
+### Removed
+
+- The two boundary casts that worked around the pre-0.52.1 stub drift
+  are gone: ``classify_change`` calls ``panproto.diff_and_classify``
+  with its three runtime arguments directly, and
+  ``DependentLens.instantiate`` passes the ``Protocol`` through
+  without re-casting it to ``Schema``. Behaviour is unchanged; the
+  call sites now type-check against the corrected stubs.
+
 ## [0.7.3] - 2026-06-07
 
 ### Added

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -110,6 +110,6 @@ Prints didactic's version followed by panproto's:
 
 ```bash
 didactic version
-# didactic 0.7.3
-# panproto 0.52.0
+# didactic 0.7.4
+# panproto 0.52.1
 ```

--- a/docs/project/stability.md
+++ b/docs/project/stability.md
@@ -40,7 +40,7 @@ each is documented in the [Changelog](changelog.md).
 
 ## panproto compatibility
 
-didactic pins panproto via a `>=` floor (currently `panproto>=0.52`).
+didactic pins panproto via a `>=` floor (currently `panproto>=0.52.1`).
 panproto's wire format may change between minor releases; didactic
 absorbs the difference internally so `import didactic` keeps working
 across panproto upgrades within the supported range.

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.3"
+version = "0.7.4"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.3"
+version = "0.7.4"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.3"
+version = "0.7.4"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.3"
+version = "0.7.4"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.52.0",
+    "panproto>=0.52.1",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -74,7 +74,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/lenses/_dependent_lens.py
+++ b/packages/didactic/src/didactic/lenses/_dependent_lens.py
@@ -44,7 +44,7 @@ didactic.Iso : the isomorphism subcase.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import panproto
@@ -388,12 +388,7 @@ class DependentLens:
         panproto.LensError
             If the chain cannot be instantiated against ``schema``.
         """
-        # ``ProtolensChain.instantiate``'s shipped stub claims
-        # ``(src: Schema, tgt: Schema)``; the runtime is
-        # ``(schema, protocol)`` with the second arg being a
-        # ``panproto.Protocol``. Cast at the boundary so we type-match
-        # the stub while passing the runtime's expected value.
-        return self._inner.instantiate(schema, cast("panproto.Schema", protocol))
+        return self._inner.instantiate(schema, protocol)
 
     # serialisation -------------------------------------------------
 

--- a/packages/didactic/src/didactic/migrations/_diff.py
+++ b/packages/didactic/src/didactic/migrations/_diff.py
@@ -18,11 +18,9 @@ panproto.diff_schemas : the runtime call.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    import panproto
-
     from didactic.models._model import Model
     from didactic.types._typing import JsonObject
 
@@ -110,24 +108,11 @@ def classify_change(old: type[Model], new: type[Model]) -> JsonObject:
         obj_kinds=["object"],
     )
 
-    # ``panproto.diff_and_classify`` accepts a third positional ``protocol``
-    # argument at runtime; the upstream stub still lists only two. Cast
-    # to a Protocol that exposes the runtime arity and return shape.
-    class _CompatReportLike(Protocol):
-        def to_dict(self) -> JsonObject: ...
-
-    class _DiffAndClassifyLike(Protocol):
-        def __call__(
-            self,
-            old: panproto.Schema,
-            new: panproto.Schema,
-            protocol: panproto.Protocol,
-            /,
-        ) -> _CompatReportLike: ...
-
-    diff_and_classify = cast("_DiffAndClassifyLike", panproto.diff_and_classify)
-    compat = diff_and_classify(old_schema, new_schema, protocol)
-    return compat.to_dict()
+    compat = panproto.diff_and_classify(old_schema, new_schema, protocol)
+    # panproto's ``to_dict`` is typed with panproto's own recursive
+    # ``JsonValue`` alias; narrow to didactic's structurally-identical
+    # ``JsonObject`` at the boundary (the same bridge ``diff`` uses).
+    return cast("JsonObject", compat.to_dict())
 
 
 def is_breaking_change(old: type[Model], new: type[Model]) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,12 +117,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.52.0" },
+    { name = "panproto", specifier = ">=0.52.1" },
 ]
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.52.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/80/aa1b6ddf2ca42f3f76092a61b85c99507deed811d62d839d6fb4a71744ae/panproto-0.52.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:106472cd46fff89b60cc38c1ebce47d11867fd5755eff89a8e3107ea86764c28", size = 11793554, upload-time = "2026-06-05T21:45:20.775Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ac/6c4b0152ecb5a482681b3599afd7f4adf47313c55b827aac15f553ce1ed5/panproto-0.52.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:3d3ce1be771b97f56f40391c8d59121e320d8209836a06ac5dc0cd9c848bc045", size = 11536442, upload-time = "2026-06-05T21:45:23.137Z" },
-    { url = "https://files.pythonhosted.org/packages/08/df/f41bf3e26dfb357999298f96b666f79bed6261138ee36f0cdf949716bc42/panproto-0.52.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:768b878b250ad1727cbcec04b5a29c7d123854d73dff42b68651c920e0124bd1", size = 12081816, upload-time = "2026-06-05T21:45:25.563Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9b/87af188bca792f7361633e1425b872212aab79d252241dfa526859f5e32c/panproto-0.52.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:dfa6644aa225ebd023a24aff70cbe89477469217eb017681f8a06c1d577ee8f3", size = 12674837, upload-time = "2026-06-05T21:45:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/25/75/0d9a74d480a2b45c7147113ba58f13b2d38797f7639a0a0f286f76812209/panproto-0.52.0-cp313-abi3-win_amd64.whl", hash = "sha256:4147b878ca55a76ec0357f8a36f8e2dec22b83c9b7a3a00f76fb6a8454812a7c", size = 11746007, upload-time = "2026-06-05T21:45:29.849Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d7/0fb6daf8704a7a2c5a14f265b3cde0380ac8290a925ad0e6c91d395d14e4/panproto-0.52.1-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60e6c22ead425e2177a780da7c8e29e884f2d2e8fae38422e6609030c521e873", size = 11795582, upload-time = "2026-06-09T19:25:38.104Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/97/d5ea226a50e197f9993149437dba76bb64e8e72760d70c08a0a446d29128/panproto-0.52.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:142500138cedcdd89927e1c9a693c3ce8a11f3995078831f37da927fd3fb4c05", size = 11536805, upload-time = "2026-06-09T19:25:41.375Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b8/1daf3c6e350bac1f8053db1d683f81e05ab03ade834d9b308f52ad1d602c/panproto-0.52.1-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2308fb27e6459e22a881d551dd3ce3c730f4c4e408ea0f2a695026889f1a747e", size = 12081852, upload-time = "2026-06-09T19:25:44.087Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6a/b1da1fb53b69c10e299bbe119a3829348d3e7a6a26f7caa9fe0431e7272c/panproto-0.52.1-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f19783031776973d4a267d0cf0cc2f52eca1d89c85a7faa837460c691545f161", size = 12672689, upload-time = "2026-06-09T19:25:47.123Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/38/2bfa2e645f6b0172537b4b0d3b330c30587cf2ae42eaae30b472baeca697/panproto-0.52.1-cp313-abi3-win_amd64.whl", hash = "sha256:2ebbf3732100a7e17855828159269985c4471c0ff92ba827e20694e6fe16e271", size = 11747817, upload-time = "2026-06-09T19:25:50.277Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

panproto 0.52.1 resyncs its `_native.pyi` stubs to the runtime (closes panproto/panproto#186). This raises the floor to `>=0.52.1` and removes the two boundary casts didactic carried to work around the drift. Behaviour is unchanged; the call sites now type-check against the corrected stubs. Bumps all four distributions to 0.7.4.

## Motivation

When didactic shipped 0.7.3 it pinned `panproto>=0.52.0`, whose stubs declared `diff_and_classify` as two-arg, `ProtolensChain.instantiate` as `(schema, schema)`, and the `Instance` accessors as methods — none matching the runtime. didactic absorbed the two load-bearing mismatches with casts in `_diff.py` and `_dependent_lens.py`. panproto/panproto#186 tracked the drift; 0.52.1 fixes it, so the casts are now provably unnecessary (and pyright strict's `reportUnnecessaryCast` would flag them against the corrected stubs).

## Changes

- `packages/didactic/src/didactic/migrations/_diff.py` — `classify_change` calls `panproto.diff_and_classify(old, new, protocol)` directly; the two local `Protocol` shim classes and the function cast are gone. The result is still narrowed to didactic's `JsonObject` (the panproto-vs-didactic `JsonValue`-alias bridge, the same one `diff` uses — unrelated to #186). Drops the now-dead `typing.Protocol` and `TYPE_CHECKING` `panproto` imports.
- `packages/didactic/src/didactic/lenses/_dependent_lens.py` — `DependentLens.instantiate` passes the `Protocol` through without the `cast("panproto.Schema", ...)`; drops the now-unused `cast` import.
- `packages/didactic/pyproject.toml` — `panproto>=0.52.1`; all four distributions and sibling `__version__` strings bumped to 0.7.4.
- `docs/` — stability page pin (`>=0.52.1`) and CLI `version` example output refreshed.
- `CHANGELOG.md` — `[0.7.4] - 2026-06-10` (Changed: floor bump + the 0.52.1 stub resync and Rust/Julia emit tightening that flows through `codegen.source`; Removed: the two casts).

## Tests

No new tests: this is a typing/dependency change with no behaviour delta. The existing suite (643 tests) covers `classify_change` / `is_breaking_change` and the `DependentLens.instantiate` path; all pass against 0.52.1. The decisive signal is pyright strict at 0 errors after the casts are removed — confirming the casts were exactly the #186 workarounds and nothing load-bearing was dropped.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`

## Compatibility

- **No user-visible change** — raised dependency floor, dead-workaround removal, docs. No public API behaves differently. Existing code keeps working; the runtime call signatures were always what didactic invoked.

## Changelog

- [x] Added a `CHANGELOG.md` entry (under `[0.7.4]`, since this PR is the version bump; a fresh `[Unreleased]` heading sits above it).

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Refs panproto/panproto#186 — fixed upstream in 0.52.1; this PR consumes the fix and removes the corresponding workarounds.