### PR TITLE
feat(synthesis): invert closed sum sorts (TaggedUnion, recursive alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The inbound synthesiser (``didactic.synthesis``: ``model_from_spec``,
+  ``models_from_specs``, ``model_from_theory``) reconstructs closed sum
+  sorts. A ``dx.TaggedUnion`` field rebuilds into a union root with one
+  variant subclass per constructor (keyed by the discriminator value
+  recovered from the constructor name), and a Model-ref recursive alias
+  rebuilds into an equivalent ``type`` alias. A model carrying either
+  shape now round-trips through the synthesiser at the Theory-spec
+  level. Variant and arm Model payloads resolve through the shared
+  ``registry`` (so an edge elsewhere binds the same class), and
+  ``models_from_specs`` orders sum-arm dependencies ahead of their
+  dependents so a forward-referenced arm resolves to the real class
+  rather than a fieldless stub. ([#45])
+
+### Notes
+
+- Three lossiness limitations of the synthesiser (scalar value kinds
+  collapsing to ``str``, ``Ref`` indistinguishable from ``Embed``, and
+  per-field defaults / metadata being absent) are inherent to the GAT
+  theory vocabulary rather than the synthesiser: a panproto ``Operation``
+  carries no containment marker or metadata slot, and ``ValueKind`` has
+  no temporal / decimal / uuid variant. These are tracked upstream for a
+  representation didactic can adopt without smuggling private data
+  through ignored spec keys.
+
+[#45]: https://github.com/panproto/didactic/issues/45
+
 ## [0.7.4] - 2026-06-10
 
 ### Changed

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -26,8 +26,10 @@ parameter list.
   `save_registry`, `load_registry`.
 - [Schema diff](diff.md): `diff`, `classify_change`,
   `is_breaking_change`.
-- [Synthesis](synthesis.md): `synthesise_migration`,
+- [Migration synthesis](synthesis.md): `synthesise_migration`,
   `SynthesisResult`.
+- [Model synthesis](model-synthesis.md): `model_from_spec`,
+  `models_from_specs`, `model_from_theory`.
 
 ## Theory and fingerprints
 

--- a/docs/reference/model-synthesis.md
+++ b/docs/reference/model-synthesis.md
@@ -1,0 +1,20 @@
+# Model synthesis (inbound)
+
+Reconstruct [Model][didactic.api.Model] classes from panproto Theory
+specs: the faithful inverse of
+[build_theory_spec][didactic.theory._theory.build_theory_spec]. For a
+hand-written Model, the regenerated class's forward spec equals the
+original's.
+
+Closed sum sorts round-trip: a `dx.TaggedUnion` field rebuilds into a
+union root with one variant per constructor, and a Model-ref recursive
+alias rebuilds into an equivalent `type` alias. Reconstruction is
+faithful at the Theory-spec level (structure), not at the level of
+Python annotations or field metadata; the function docstrings below
+spell out the recoverable / unrecoverable split.
+
+::: didactic.api.model_from_spec
+
+::: didactic.api.models_from_specs
+
+::: didactic.api.model_from_theory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,8 @@ nav:
     - Lens: reference/lens.md
     - Migrations: reference/migrations.md
     - Schema diff: reference/diff.md
-    - Synthesis: reference/synthesis.md
+    - Migration synthesis: reference/synthesis.md
+    - Model synthesis: reference/model-synthesis.md
     - Repository: reference/repository.md
     - Code generation: reference/codegen.md
     - Self-describing: reference/self-describing.md

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -32,7 +32,7 @@ sub-package (``didactic.api``, ``didactic.pydantic``,
 resolve cross-distribution imports without a ``pkgutil`` workaround.
 """
 
-from didactic import codegen
+from didactic import codegen, synthesis
 from didactic._self_describing import (
     FingerprintRegistry,
     embed_schema_uri,
@@ -70,6 +70,11 @@ from didactic.migrations._synthesis import SynthesisResult, synthesise_migration
 from didactic.models._config import DEFAULT_CONFIG, ExtraPolicy, ModelConfig
 from didactic.models._model import BaseModel, Model
 from didactic.models._root import RootModel, TypeAdapter
+from didactic.synthesis._synthesis import (
+    model_from_spec,
+    model_from_theory,
+    models_from_specs,
+)
 from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
@@ -122,11 +127,15 @@ __all__ = [
     "lens",
     "load_registry",
     "migrate",
+    "model_from_spec",
+    "model_from_theory",
     "model_validator",
+    "models_from_specs",
     "register_migration",
     "resolve_backrefs",
     "save_registry",
     "schema_uri",
+    "synthesis",
     "synthesise_migration",
     "testing",
     "types",

--- a/packages/didactic/src/didactic/synthesis/__init__.py
+++ b/packages/didactic/src/didactic/synthesis/__init__.py
@@ -1,0 +1,18 @@
+"""Inbound synthesis: panproto Theory specs back into didactic Models.
+
+The faithful inverse of [build_theory_spec][didactic.theory._theory.build_theory_spec].
+See [didactic.synthesis._synthesis][] for the reconstruction strategy and
+its honest limitations.
+"""
+
+from didactic.synthesis._synthesis import (
+    model_from_spec,
+    model_from_theory,
+    models_from_specs,
+)
+
+__all__ = [
+    "model_from_spec",
+    "model_from_theory",
+    "models_from_specs",
+]

--- a/packages/didactic/src/didactic/synthesis/_synthesis.py
+++ b/packages/didactic/src/didactic/synthesis/_synthesis.py
@@ -1,0 +1,691 @@
+"""Synthesise didactic ``Model`` classes from panproto Theory specs.
+
+This module is the faithful inverse of
+[build_theory_spec][didactic.theory._theory.build_theory_spec]: it takes a
+single Theory spec dict (or a ``panproto.Theory``) and reconstructs a
+[Model][didactic.api.Model] subclass whose forward spec round-trips.
+
+Reconstruction strategy
+------------------------
+The forward path emits, per model:
+
+- one primary ``Structural`` sort named after the model,
+- one constraint sort per scalar / container / optional field, named
+  ``<Model>_<field>`` and carrying a ``{"Val": <ValueKind>}`` kind,
+- one accessor op per field, whose ``output`` is either the field's
+  constraint sort (for value fields) or another model's primary sort
+  (for ``Ref[T]`` / ``Embed[T]`` edges).
+
+The synthesiser walks the ops in declaration order, dispatching on each
+op's ``output``:
+
+- output names a declared ``{"Val": K}`` constraint sort -> a value
+  field; the ValueKind is mapped back to a representative Python scalar
+  (see :data:`_PY_FOR_VALUE_KIND`),
+- output names another sort that is *not* a value constraint -> an edge
+  field, reconstructed as ``dx.Ref[Target]``.
+
+Honest limitations (the spec is lossy)
+--------------------------------------
+The forward Theory spec discards every Python-side distinction that
+panproto's ``ValueKind`` enum does not carry:
+
+- Container element types collapse: ``tuple[int, ...]``,
+  ``frozenset[str]``, ``dict[str, int]``, ``str | None``, ``Decimal``,
+  ``datetime``, ``date``, ``time``, ``UUID`` all encode to
+  ``{"Val": "Str"}`` (see ``_theory._VALUE_KIND_FOR_SORT``). The
+  synthesiser therefore maps ``Str`` back to a plain ``str``; the
+  regenerated model's forward spec is byte-for-byte identical to the
+  original, but the Python annotation is *not* recovered.
+- ``Ref[T]`` and ``Embed[T]`` produce identical edge ops, so they are
+  indistinguishable in the spec. Both are reconstructed as ``Ref[T]``;
+  the forward spec of a ``Ref``-regenerated model equals that of the
+  ``Embed`` original because both emit a bare edge op.
+- Field metadata (descriptions, examples, defaults, validators, axioms,
+  aliases, ``nominal`` flags) is not present in the spec and cannot be
+  recovered. Every reconstructed field is required (no default) and
+  carries no metadata.
+
+Round-trip equality is therefore on the *Theory spec* (structure), never
+on Python-side metadata.
+
+Closed sum sorts (``TaggedUnion`` and Model-ref recursive aliases)
+-----------------------------------------------------------------
+A closed sum sort (``closure: {"Closed": [...]}``) carries one
+constructor op per arm. The synthesiser inverts both shapes the forward
+path emits:
+
+- A sum sort carrying a ``discriminator`` key comes from a
+  ``dx.TaggedUnion`` root. The synthesiser rebuilds the root with that
+  discriminator and one variant subclass per constructor, keyed by the
+  discriminator value recovered from the constructor name
+  (``<Union>_<value>``). Variant payload fields are absent from the
+  parent spec, so each rebuilt variant carries only its discriminator
+  field; that is enough for the parent's forward spec to round-trip.
+- A sum sort without a discriminator comes from a Model-ref recursive
+  alias. The synthesiser reads the constructor arms (primitive value
+  helpers, container helpers, and Model-sort inputs) and rebuilds an
+  equivalent ``type`` alias whose forward spec matches.
+
+The discriminator value's Python type is not recovered: a constructor
+name is a string, so a variant's discriminator field is rebuilt as
+``Literal["<value>"]`` even when the original pinned a non-string
+literal. The constructor name round-trips regardless, so the forward
+spec is preserved.
+
+A ``panproto.Theory`` does not carry the ``discriminator`` key (it is
+not part of the GAT theory vocabulary, so the native ``to_dict`` drops
+it). Reconstructing a ``TaggedUnion`` therefore needs the spec dict from
+``build_theory_spec``; ``model_from_theory`` recovers Model-ref aliases
+but raises on a discriminator-bearing sum sort whose key the Theory has
+dropped.
+
+See Also
+--------
+didactic.theory._theory.build_theory_spec : the forward path inverted here.
+didactic.types._types.classify : the type-classification this undoes.
+"""
+
+from __future__ import annotations
+
+import types as _types
+from typing import TYPE_CHECKING, Literal, cast
+
+from didactic.fields._refs import Ref
+from didactic.fields._unions import TaggedUnion
+from didactic.models._model import Model
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from didactic.theory._theory import TheorySpec
+    from didactic.types._typing import JsonValue
+
+
+# Inverse of ``_theory._VALUE_KIND_FOR_SORT``. The forward map is
+# many-to-one (Str absorbs datetime, decimal, containers, optionals, ...),
+# so the inverse picks one representative Python type per ValueKind. ``Str``
+# maps to ``str`` because that is the forward path's catch-all sink; a
+# regenerated ``str`` field re-encodes to ``{"Val": "Str"}``, so the spec
+# round-trips even though the original Python type is not recovered.
+_PY_FOR_VALUE_KIND: dict[str, type] = {
+    "Str": str,
+    "Int": int,
+    "Float": float,
+    "Bool": bool,
+    "Bytes": bytes,
+}
+
+
+def model_from_spec(
+    spec: TheorySpec | object,
+    *,
+    name: str | None = None,
+    base: type[Model] = Model,
+    registry: dict[str, type[Model]] | None = None,
+) -> type[Model]:
+    """Synthesise a didactic ``Model`` class from a single Theory spec.
+
+    Parameters
+    ----------
+    spec
+        Either a ``TheorySpec`` dict (the shape produced by
+        ``build_theory_spec``) or a ``panproto.Theory``. A Theory is
+        detected by the presence of a ``to_dict`` method and converted.
+    name
+        Class name override. Defaults to the spec's ``name`` field.
+    base
+        Base class for the synthesised model. Defaults to ``Model``.
+        Overridden per-spec when the spec's ``extends`` names a model
+        present in ``registry``.
+    registry
+        Mapping of sort name to already-synthesised ``Model`` classes,
+        used to resolve ``extends`` parents and ``Ref`` / ``Embed`` edge
+        targets. Edge targets absent from the registry are left as string
+        forward references so mutual recursion resolves once every model
+        exists. The newly synthesised class is registered under its own
+        name before return.
+
+    Returns
+    -------
+    type[Model]
+        The synthesised ``Model`` subclass.
+
+    Raises
+    ------
+    NotImplementedError
+        If the spec carries a discriminator-bearing closed sum sort whose
+        ``discriminator`` key has been dropped (the ``panproto.Theory``
+        path); pass the ``build_theory_spec`` dict to recover it.
+
+    Notes
+    -----
+    The reconstruction is faithful at the Theory-spec level only. See the
+    module docstring for the recoverable / unrecoverable split.
+    """
+    spec_dict = _as_spec_dict(spec)
+    registry = {} if registry is None else registry
+
+    sort_name = cast("str", spec_dict.get("name") or name or "Synthesised")
+    class_name = name or sort_name
+
+    sorts = cast("list[dict[str, JsonValue]]", spec_dict.get("sorts", []))
+    ops = cast("list[dict[str, JsonValue]]", spec_dict.get("ops", []))
+    extends = cast("list[str]", spec_dict.get("extends", []))
+
+    # index the value-constraint sorts by name so each accessor op can be
+    # classified as value-field-vs-edge from its output sort
+    value_kinds = _value_constraint_kinds(sorts)
+
+    # invert each closed sum sort into a Python type (TaggedUnion root or
+    # Model-ref alias), keyed by sort name. ``constructor_names`` collects
+    # the per-arm constructor ops so the field walk skips them: they are
+    # introduction forms for the sum, not accessor fields of this model.
+    sum_types, constructor_names = _build_sum_types(sorts, ops, registry)
+
+    annotations: dict[str, object] = {}
+    for op in ops:
+        fname = cast("str", op["name"])
+        if fname in constructor_names:
+            continue
+        output = cast("str", op["output"])
+        if output in sum_types:
+            annotations[fname] = sum_types[output]
+        elif output in value_kinds:
+            annotations[fname] = _PY_FOR_VALUE_KIND.get(value_kinds[output], str)
+        else:
+            # the output is another model's primary sort: an edge field.
+            # Ref and Embed are indistinguishable in the spec; reconstruct
+            # as Ref. Resolve the target through the registry when present,
+            # else leave a string forward reference.
+            target = registry.get(output)
+            annotations[fname] = Ref[target if target is not None else output]
+
+    bases = _resolve_bases(extends, base, registry)
+
+    namespace: dict[str, object] = {
+        "__annotations__": annotations,
+        "__module__": __name__,
+        "__qualname__": class_name,
+        "__doc__": f"Model synthesised from the {sort_name!r} Theory spec.",
+    }
+
+    new_cls = cast("type[Model]", type(class_name, bases, namespace))
+    # register under the spec's sort name so later models resolve edges /
+    # extends against this class
+    registry[sort_name] = new_cls
+    return new_cls
+
+
+def models_from_specs(
+    specs: Iterable[TheorySpec | object],
+    *,
+    base: type[Model] = Model,
+) -> dict[str, type[Model]]:
+    """Synthesise many models, sharing one registry for cross-references.
+
+    Parameters
+    ----------
+    specs
+        An iterable of ``TheorySpec`` dicts or ``panproto.Theory`` objects.
+    base
+        Base class for models that declare no ``extends`` parent.
+
+    Returns
+    -------
+    dict[str, type[Model]]
+        Mapping of each model's sort name to its synthesised class.
+
+    Notes
+    -----
+    Specs are topologically ordered by their ``extends`` dependency so a
+    parent is always synthesised before its child. ``Ref`` / ``Embed``
+    edge targets that form cycles (mutually-referencing models) resolve
+    through the shared registry: the first model to reference a not-yet
+    synthesised target gets a string forward reference, which didactic's
+    metaclass closes once both classes exist.
+
+    Ordering only sequences ``extends`` (inheritance) dependencies, not
+    edge dependencies, because edge targets tolerate forward references
+    while base classes do not.
+    """
+    materialised = [_as_spec_dict(s) for s in specs]
+    ordered = _topo_sort_by_extends(materialised)
+
+    registry: dict[str, type[Model]] = {}
+    for spec_dict in ordered:
+        model_from_spec(spec_dict, base=base, registry=registry)
+    return registry
+
+
+def model_from_theory(theory: object, **kwargs: object) -> type[Model]:
+    """Synthesise a ``Model`` from a ``panproto.Theory``.
+
+    Parameters
+    ----------
+    theory
+        A ``panproto.Theory`` instance.
+    **kwargs
+        Forwarded to [model_from_spec][didactic.synthesis.model_from_spec]
+        (``name``, ``base``, ``registry``).
+
+    Returns
+    -------
+    type[Model]
+        The synthesised ``Model`` subclass.
+    """
+    name = cast("str | None", kwargs.pop("name", None))
+    base = cast("type[Model]", kwargs.pop("base", Model))
+    registry = cast("dict[str, type[Model]] | None", kwargs.pop("registry", None))
+    return model_from_spec(theory, name=name, base=base, registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_spec_dict(spec: TheorySpec | object) -> dict[str, JsonValue]:
+    """Coerce a spec argument to a plain dict.
+
+    Accepts either a ``TheorySpec`` mapping or a ``panproto.Theory``
+    (detected by a callable ``to_dict`` attribute).
+    """
+    to_dict = getattr(spec, "to_dict", None)
+    if callable(to_dict) and not isinstance(spec, dict):
+        return cast("dict[str, JsonValue]", to_dict())
+    return cast("dict[str, JsonValue]", spec)
+
+
+def _value_constraint_kinds(sorts: list[dict[str, JsonValue]]) -> dict[str, str]:
+    """Index value-constraint sorts to their ValueKind variant.
+
+    A value-constraint sort is one whose ``kind`` is ``{"Val": K}``.
+    Structural sorts (the primary sort and any closed sum sorts) are
+    skipped. The returned mapping is keyed by sort name so an accessor op
+    can be classified value-field-vs-edge from its ``output``.
+    """
+    kinds: dict[str, str] = {}
+    for sort in sorts:
+        kind = sort.get("kind")
+        if isinstance(kind, dict) and "Val" in kind:
+            kinds[cast("str", sort["name"])] = cast("str", kind["Val"])
+    return kinds
+
+
+# ---------------------------------------------------------------------------
+# closed sum sorts (TaggedUnion roots and Model-ref recursive aliases)
+# ---------------------------------------------------------------------------
+
+# Inverse of ``_types._PRIMITIVE_TAGS`` (the alias primitive-arm tags). The
+# forward path names a primitive arm's value-helper sort
+# ``<Alias>__<tag>_value``; the synthesiser maps the tag back to its Python
+# type. ``none`` denotes ``NoneType`` (a bare ``None`` arm in the union).
+_PY_FOR_PRIMITIVE_TAG: dict[str, object] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "none": None,
+}
+
+
+def _build_sum_types(
+    sorts: list[dict[str, JsonValue]],
+    ops: list[dict[str, JsonValue]],
+    registry: dict[str, type[Model]],
+) -> tuple[dict[str, object], set[str]]:
+    """Invert every closed sum sort in a spec into a Python type.
+
+    Parameters
+    ----------
+    sorts
+        The spec's sort records.
+    ops
+        The spec's operation records; the constructor ops for each closed
+        sum sort are read here.
+    registry
+        Shared sort-name to class map. Synthesised ``TaggedUnion`` roots,
+        their variants, and Model arms are registered so later models
+        resolve edges against the same objects.
+
+    Returns
+    -------
+    tuple
+        ``(sum_types, constructor_names)``. ``sum_types`` maps each closed
+        sum sort name to the synthesised Python type (a ``TaggedUnion``
+        subclass or a ``type`` alias). ``constructor_names`` is every
+        per-arm constructor op name, so the field walk can skip them.
+    """
+    closed_sums = {cast("str", s["name"]): s for s in sorts if _is_closed_sum(s)}
+    ops_by_name = {cast("str", op["name"]): op for op in ops}
+
+    constructor_names: set[str] = set()
+    arms_by_sum: dict[str, list[tuple[str, str | None]]] = {}
+    for sum_name, sort in closed_sums.items():
+        closure = cast("dict[str, JsonValue]", sort["closure"])
+        closed = cast("list[str]", closure["Closed"])
+        arms: list[tuple[str, str | None]] = []
+        for ctor_name in closed:
+            constructor_names.add(ctor_name)
+            input_sort = _constructor_input_sort(ops_by_name.get(ctor_name))
+            arms.append((ctor_name, input_sort))
+        arms_by_sum[sum_name] = arms
+
+    sum_types: dict[str, object] = {}
+    for sum_name, sort in closed_sums.items():
+        arms = arms_by_sum[sum_name]
+        if "discriminator" in sort:
+            sum_types[sum_name] = _build_tagged_union(
+                sum_name, cast("str", sort["discriminator"]), arms, registry
+            )
+        elif _has_alias_arm(sum_name, arms):
+            sum_types[sum_name] = _build_model_ref_alias(sum_name, arms, registry)
+        else:
+            # A closed sum whose arms are all Model sorts, with no
+            # value/container helper, is a TaggedUnion whose discriminator
+            # key the carrier dropped (the panproto.Theory path drops
+            # didactic-private keys). Without the discriminator field name
+            # the union cannot be rebuilt.
+            msg = (
+                f"closed sum sort {sum_name!r} has no discriminator key and no "
+                "value or container arm, so it is a TaggedUnion whose "
+                "discriminator was dropped by a panproto.Theory. Synthesise "
+                "from the build_theory_spec dict, which preserves it."
+            )
+            raise NotImplementedError(msg)
+    return sum_types, constructor_names
+
+
+def _has_alias_arm(sum_name: str, arms: list[tuple[str, str | None]]) -> bool:
+    """Return True iff any arm is a value or container helper (alias shape).
+
+    A Model-ref alias always carries at least one container arm (its
+    self-reference) and may carry primitive value arms; both route through
+    ``<sum_name>__...`` helper sorts. A discriminator-bearing union routes
+    every arm through a variant's primary sort instead.
+    """
+    helper_prefix = f"{sum_name}__"
+    return any(
+        input_sort is not None
+        and input_sort.startswith(helper_prefix)
+        and input_sort.endswith("_value")
+        for input_sort in (arm[1] for arm in arms)
+    )
+
+
+def _is_closed_sum(sort: dict[str, JsonValue]) -> bool:
+    """Return True iff ``sort`` is a closed sum sort (``closure`` is ``Closed``)."""
+    closure = sort.get("closure")
+    return isinstance(closure, dict) and "Closed" in closure
+
+
+def _constructor_input_sort(op: dict[str, JsonValue] | None) -> str | None:
+    """Return a constructor op's single input sort name, or ``None``.
+
+    Constructor ops are unary (one ``(param, sort, implicit)`` input);
+    the input sort is the arm's payload (a value-helper sort, a container
+    helper, or a Model's primary sort).
+    """
+    if op is None:
+        return None
+    inputs = cast("list[list[str]]", op.get("inputs", []))
+    if not inputs:
+        return None
+    return inputs[0][1]
+
+
+def _build_tagged_union(
+    union_name: str,
+    discriminator: str,
+    arms: list[tuple[str, str | None]],
+    registry: dict[str, type[Model]],
+) -> type[TaggedUnion]:
+    """Rebuild a ``dx.TaggedUnion`` root and its variants from a sum sort.
+
+    Each arm's constructor name is ``<union_name>_<discriminator-value>``
+    and its input sort is the variant's primary sort (the variant class
+    name). The rebuilt root declares ``discriminator``; each variant
+    subclasses the root and pins its discriminator field to the value
+    recovered from the constructor name. Variant payload fields are not
+    present in this spec, so a variant carries only its discriminator.
+    """
+    _require_identifier(union_name, "TaggedUnion sort")
+    _require_identifier(discriminator, "discriminator field")
+
+    root = cast(
+        "type[TaggedUnion]",
+        _types.new_class(
+            union_name,
+            (TaggedUnion,),
+            {"discriminator": discriminator},
+            lambda ns: ns.update({"__module__": __name__, "__qualname__": union_name}),
+        ),
+    )
+    for ctor_name, payload_sort in arms:
+        disc_value = ctor_name.removeprefix(f"{union_name}_")
+        variant_name = payload_sort or f"{union_name}_{disc_value}"
+        _require_identifier(variant_name, "variant sort")
+        annotations = {discriminator: Literal[disc_value]}
+        variant = _types.new_class(
+            variant_name,
+            (root,),
+            {},
+            lambda ns, _ann=annotations, _name=variant_name: ns.update(
+                {
+                    "__annotations__": _ann,
+                    "__module__": __name__,
+                    "__qualname__": _name,
+                }
+            ),
+        )
+        registry.setdefault(variant_name, cast("type[Model]", variant))
+    registry[union_name] = cast("type[Model]", root)
+    return root
+
+
+def _build_model_ref_alias(
+    alias_name: str,
+    arms: list[tuple[str, str | None]],
+    registry: dict[str, type[Model]],
+) -> object:
+    """Rebuild a Model-ref recursive ``type`` alias from a sum sort.
+
+    The forward path emits, per arm: a primitive value helper named
+    ``<alias>__<tag>_value``, a shared container helper
+    ``<alias>__list_value`` / ``<alias>__dict_value`` (constructor name
+    ending ``_list`` / ``_tuple`` / ``_dict``), or a Model's primary sort
+    directly. The arm payloads of container elements collapse to a string
+    helper, so the rebuilt alias references itself in its container arms;
+    this reproduces the forward spec exactly while making the alias
+    self-referential (the shape ``classify`` requires).
+    """
+    _require_identifier(alias_name, "alias sort")
+    value_prefix = f"{alias_name}__"
+    arm_exprs: list[str] = []
+    arm_namespace: dict[str, object] = {
+        "str": str,
+        "int": int,
+        "float": float,
+        "bool": bool,
+        "tuple": tuple,
+        "dict": dict,
+        "list": list,
+    }
+    for ctor_name, input_sort in arms:
+        if input_sort == f"{alias_name}__dict_value":
+            arm_exprs.append(f"dict[str, {alias_name!r}]")
+        elif input_sort == f"{alias_name}__list_value":
+            if ctor_name.endswith("_tuple"):
+                arm_exprs.append(f"tuple[{alias_name!r}, ...]")
+            else:
+                arm_exprs.append(f"list[{alias_name!r}]")
+        elif (
+            input_sort is not None
+            and input_sort.startswith(value_prefix)
+            and input_sort.endswith("_value")
+        ):
+            tag = input_sort[len(value_prefix) : -len("_value")]
+            arm_exprs.append("None" if tag == "none" else _primitive_arm_expr(tag))
+        else:
+            # Model arm: the input sort is the arm Model's primary sort.
+            model_name = input_sort or ctor_name
+            _require_identifier(model_name, "Model arm sort")
+            arm_namespace[model_name] = registry.get(model_name) or _stub_model(
+                model_name, registry
+            )
+            arm_exprs.append(model_name)
+
+    statement = f"type {alias_name} = " + " | ".join(arm_exprs)
+    # ``exec`` builds a genuine PEP 695 alias whose forward references
+    # (the self-reference and Model arms) resolve lazily against
+    # ``arm_namespace``. Every interpolated name is identifier-checked
+    # above, so the statement carries only vetted names.
+    exec(statement, arm_namespace)
+    return arm_namespace[alias_name]
+
+
+def _primitive_arm_expr(tag: str) -> str:
+    """Return the source expression for a primitive alias arm tag.
+
+    Raises
+    ------
+    ValueError
+        If ``tag`` is not one of the known primitive tags.
+    """
+    if tag not in _PY_FOR_PRIMITIVE_TAG:
+        msg = f"unknown primitive alias arm tag {tag!r}"
+        raise ValueError(msg)
+    return tag
+
+
+def _stub_model(name: str, registry: dict[str, type[Model]]) -> type[Model]:
+    """Build and register a fieldless ``Model`` to stand in for an arm sort.
+
+    A sum sort's Model arms reference a model by name only; the arm
+    model's own fields are absent from this spec. A fieldless stub
+    reproduces the arm's constructor op (whose input is the model's
+    primary sort) so the forward spec round-trips.
+    """
+    stub = cast(
+        "type[Model]",
+        type(
+            name,
+            (Model,),
+            {
+                "__annotations__": {},
+                "__module__": __name__,
+                "__qualname__": name,
+                "__doc__": f"Stub Model for the {name!r} sum-sort arm.",
+            },
+        ),
+    )
+    registry.setdefault(name, stub)
+    return stub
+
+
+def _require_identifier(name: str, what: str) -> None:
+    """Raise ``ValueError`` unless ``name`` is a valid Python identifier.
+
+    The alias reconstructor interpolates sort names into a ``type``
+    statement; gating on identifiers keeps the statement to vetted names.
+    """
+    if not name.isidentifier():
+        msg = f"{what} name {name!r} is not a valid Python identifier"
+        raise ValueError(msg)
+
+
+def _resolve_bases(
+    extends: list[str],
+    base: type[Model],
+    registry: dict[str, type[Model]],
+) -> tuple[type[Model], ...]:
+    """Resolve a spec's ``extends`` names to base classes via the registry.
+
+    Names present in the registry become real base classes (in declared
+    order). When ``extends`` resolves to no registered parent, the
+    supplied ``base`` is used as the sole base.
+    """
+    resolved = [registry[name] for name in extends if name in registry]
+    if resolved:
+        return tuple(resolved)
+    return (base,)
+
+
+def _topo_sort_by_extends(
+    specs: list[dict[str, JsonValue]],
+) -> list[dict[str, JsonValue]]:
+    """Order specs so each spec's dependencies precede it.
+
+    Dependencies are a spec's ``extends`` parents (a hard dependency:
+    a base class must exist before its subclass) and its closed-sum-sort
+    Model arms (a soft dependency: ordering them first lets a union
+    variant or alias arm resolve to the fully-synthesised arm Model
+    rather than a fieldless stub).
+
+    Parameters
+    ----------
+    specs
+        Spec dicts to order.
+
+    Returns
+    -------
+    list[dict]
+        The specs, dependencies first. Names not in the input set are
+        skipped (resolved to the default base or a stub at synthesis
+        time). Cycles fall back to input order for the remaining specs;
+        the edge / stub forward-reference paths close them.
+    """
+    by_name = {cast("str", s["name"]): s for s in specs}
+    ordered: list[dict[str, JsonValue]] = []
+    placed: set[str] = set()
+
+    def visit(name: str, stack: frozenset[str]) -> None:
+        if name in placed or name not in by_name or name in stack:
+            return
+        spec = by_name[name]
+        for dep in _spec_dependencies(spec):
+            visit(dep, stack | {name})
+        placed.add(name)
+        ordered.append(spec)
+
+    for spec in specs:
+        visit(cast("str", spec["name"]), frozenset())
+    return ordered
+
+
+def _spec_dependencies(spec: dict[str, JsonValue]) -> list[str]:
+    """Return the sort names a spec should be ordered after.
+
+    These are the spec's ``extends`` parents plus the Model arms of any
+    closed sum sort it declares (a sum-arm Model is a constructor op
+    input that is neither a value/container helper nor the model's own
+    field-constraint sort).
+    """
+    deps: list[str] = list(cast("list[str]", spec.get("extends", [])))
+    sorts = cast("list[dict[str, JsonValue]]", spec.get("sorts", []))
+    ops = cast("list[dict[str, JsonValue]]", spec.get("ops", []))
+    closed_sums = {cast("str", s["name"]) for s in sorts if _is_closed_sum(s)}
+    if not closed_sums:
+        return deps
+    value_names = set(_value_constraint_kinds(sorts))
+    for op in ops:
+        if cast("str", op["output"]) not in closed_sums:
+            continue
+        arm_sort = _constructor_input_sort(op)
+        # a Model arm is a constructor input that names a structural sort
+        # (not a value/container helper of the sum)
+        if (
+            arm_sort is not None
+            and arm_sort not in value_names
+            and not arm_sort.startswith(f"{cast('str', op['output'])}__")
+        ):
+            deps.append(arm_sort)
+    return deps
+
+
+__all__ = [
+    "model_from_spec",
+    "model_from_theory",
+    "models_from_specs",
+]

--- a/packages/didactic/tests/test_synthesis.py
+++ b/packages/didactic/tests/test_synthesis.py
@@ -1,0 +1,699 @@
+# Tests build Model classes and feed their Theory specs back through the
+# synthesiser; pyright flags class-keyed dicts as potentially unhashable
+# (Model is hashable by class identity at runtime). Tracked in
+# panproto/didactic#1.
+"""Tests for the inbound spec -> Model synthesiser.
+
+The primary correctness contract is a *Theory-spec* round-trip against
+didactic's own forward path: for a hand-written ``dx.Model``, the
+regenerated class's ``build_theory_spec`` must equal the original's. The
+spec is lossy (every non-scalar collapses to ``{"Val": "Str"}``; Ref and
+Embed share an edge shape), so equality is on structure, not on the
+Python annotations.
+
+The spec-dict round-trip tests run unconditionally. The
+``panproto.Theory`` path is guarded with ``importorskip`` because it needs
+the panproto runtime.
+"""
+
+from typing import Literal, cast
+
+import pytest
+
+import didactic.api as dx
+from didactic.synthesis import (
+    model_from_spec,
+    model_from_theory,
+    models_from_specs,
+)
+from didactic.theory._theory import build_theory_spec
+
+
+# ---------------------------------------------------------------------------
+# representative hand-written models
+# ---------------------------------------------------------------------------
+
+
+class Scalars(dx.Model):
+    """Every registered scalar; exercises each ValueKind inverse."""
+
+    s: str
+    i: int
+    f: float
+    b: bool
+    by: bytes
+
+
+class Optionals(dx.Model):
+    """Optionals collapse to Str on the forward path."""
+
+    a: str
+    maybe: str | None = None
+    maybe_int: int | None = None
+
+
+class Containers(dx.Model):
+    """Tuple / frozenset / dict all collapse to Str on the forward path."""
+
+    items: tuple[int, ...]
+    tags: frozenset[str]
+    by_name: dict[str, int]
+
+
+class RefTarget(dx.Model):
+    """Target of a Ref edge."""
+
+    id: str
+
+
+class RefHolder(dx.Model):
+    """Holds a Ref edge to RefTarget."""
+
+    id: str
+    target: dx.Ref[RefTarget]
+
+
+class EmbedHolder(dx.Model):
+    """Holds an Embed edge to RefTarget."""
+
+    id: str
+    inner: dx.Embed[RefTarget]
+
+
+class Node(dx.Model):
+    """Mutually-recursive pair with Other."""
+
+    id: str
+    other: dx.Ref["Other"]  # noqa: UP037  forward ref; Other is defined below
+
+
+class Other(dx.Model):
+    """Mutually-recursive pair with Node."""
+
+    id: str
+    node: dx.Ref[Node]
+
+
+class InheritBase(dx.Model):
+    """Single-inheritance base."""
+
+    id: str
+
+
+class InheritSub(InheritBase):
+    """Single-inheritance child adding a field."""
+
+    extra: int
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip(model: type[dx.Model], *, deps: list[type[dx.Model]] | None = None):
+    """Synthesise from ``model``'s spec and return the regenerated class.
+
+    ``deps`` are dependency models (Ref/Embed targets, bases) whose specs
+    populate the shared registry before ``model`` is synthesised, so edges
+    and ``extends`` resolve to real classes.
+    """
+    registry: dict[str, type[dx.Model]] = {}
+    for dep in deps or []:
+        model_from_spec(build_theory_spec(dep), registry=registry)
+    return model_from_spec(build_theory_spec(model), registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# spec-dict round-trip (no panproto runtime required)
+# ---------------------------------------------------------------------------
+
+
+def test_scalars_spec_roundtrip() -> None:
+    regen = _roundtrip(Scalars)
+    assert build_theory_spec(regen) == build_theory_spec(Scalars)
+    assert set(regen.__field_specs__) == set(Scalars.__field_specs__)
+
+
+def test_scalars_instance_roundtrip() -> None:
+    regen = _roundtrip(Scalars)
+    inst = regen(s="x", i=1, f=2.5, b=True, by=b"\x00\x01")
+    dumped = inst.model_dump()
+    assert dumped["s"] == "x"
+    assert dumped["i"] == 1
+    # model_validate accepts the dumped dict back
+    again = regen.model_validate(dumped)
+    assert again == inst
+
+
+def test_optionals_spec_roundtrip() -> None:
+    regen = _roundtrip(Optionals)
+    assert build_theory_spec(regen) == build_theory_spec(Optionals)
+    assert set(regen.__field_specs__) == set(Optionals.__field_specs__)
+
+
+def test_containers_spec_roundtrip() -> None:
+    # tuple / frozenset / dict all collapse to {"Val": "Str"} on the
+    # forward path, so the regenerated str-typed fields produce an
+    # identical spec.
+    regen = _roundtrip(Containers)
+    assert build_theory_spec(regen) == build_theory_spec(Containers)
+    assert set(regen.__field_specs__) == set(Containers.__field_specs__)
+
+
+def test_ref_spec_roundtrip() -> None:
+    regen = _roundtrip(RefHolder, deps=[RefTarget])
+    assert build_theory_spec(regen) == build_theory_spec(RefHolder)
+    assert set(regen.__field_specs__) == set(RefHolder.__field_specs__)
+    # the edge op points at the target's primary sort
+    op_by_name = {op["name"]: op for op in build_theory_spec(regen)["ops"]}
+    assert op_by_name["target"]["output"] == "RefTarget"
+
+
+def test_embed_spec_roundtrip() -> None:
+    # Embed and Ref share an edge shape in the spec, so an Embed model's
+    # spec round-trips through a Ref reconstruction.
+    regen = _roundtrip(EmbedHolder, deps=[RefTarget])
+    assert build_theory_spec(regen) == build_theory_spec(EmbedHolder)
+    assert set(regen.__field_specs__) == set(EmbedHolder.__field_specs__)
+
+
+def test_mutual_recursion_spec_roundtrip() -> None:
+    regen = models_from_specs([build_theory_spec(Node), build_theory_spec(Other)])
+    assert build_theory_spec(regen["Node"]) == build_theory_spec(Node)
+    assert build_theory_spec(regen["Other"]) == build_theory_spec(Other)
+    # the edges resolve to the real regenerated classes (not forward strings)
+    node_op = {op["name"]: op for op in build_theory_spec(regen["Node"])["ops"]}
+    assert node_op["other"]["output"] == "Other"
+
+
+def test_inheritance_spec_roundtrip() -> None:
+    # The forward path FLATTENS single inheritance: the child's spec
+    # carries every inherited field inline and ``extends == []`` (the
+    # metaclass walks the MRO when collecting field specs). The synthesised
+    # child is therefore a flat model with the same fields, and its spec
+    # round-trips even though the subclass relationship is not recovered.
+    assert build_theory_spec(InheritSub)["extends"] == []
+    regen = models_from_specs(
+        [build_theory_spec(InheritBase), build_theory_spec(InheritSub)]
+    )
+    sub = regen["InheritSub"]
+    assert build_theory_spec(sub) == build_theory_spec(InheritSub)
+    # inherited + own fields are both present (flattened)
+    assert set(sub.__field_specs__) == set(InheritSub.__field_specs__)
+
+
+def test_extends_resolves_to_registered_base() -> None:
+    # When a spec DOES carry an ``extends`` (e.g. a hand-authored spec or a
+    # future forward path that emits it), the synthesised child really
+    # subclasses the registered base.
+    base_spec: dict[str, object] = {
+        "name": "Animal",
+        "extends": [],
+        "sorts": [
+            {"name": "Animal", "params": [], "kind": "Structural", "closure": "Open"},
+            {
+                "name": "Animal_legs",
+                "params": [],
+                "kind": {"Val": "Int"},
+                "closure": "Open",
+            },
+        ],
+        "ops": [
+            {
+                "name": "legs",
+                "inputs": [["self", "Animal", "No"]],
+                "output": "Animal_legs",
+            },
+        ],
+        "eqs": [],
+        "directed_eqs": [],
+        "policies": [],
+    }
+    child_spec: dict[str, object] = {
+        "name": "Dog",
+        "extends": ["Animal"],
+        "sorts": [
+            {"name": "Dog", "params": [], "kind": "Structural", "closure": "Open"},
+            {
+                "name": "Dog_name",
+                "params": [],
+                "kind": {"Val": "Str"},
+                "closure": "Open",
+            },
+        ],
+        "ops": [
+            {"name": "name", "inputs": [["self", "Dog", "No"]], "output": "Dog_name"},
+        ],
+        "eqs": [],
+        "directed_eqs": [],
+        "policies": [],
+    }
+    regen = models_from_specs([cast("object", base_spec), cast("object", child_spec)])
+    assert issubclass(regen["Dog"], regen["Animal"])
+    # the child inherits the base's field plus its own
+    assert "legs" in regen["Dog"].__field_specs__
+    assert "name" in regen["Dog"].__field_specs__
+
+
+def test_models_from_specs_returns_all() -> None:
+    regen = models_from_specs(
+        [
+            build_theory_spec(RefTarget),
+            build_theory_spec(RefHolder),
+            build_theory_spec(EmbedHolder),
+        ]
+    )
+    assert set(regen) == {"RefTarget", "RefHolder", "EmbedHolder"}
+
+
+def test_name_override() -> None:
+    regen = model_from_spec(build_theory_spec(Scalars), name="Renamed")
+    assert regen.__name__ == "Renamed"
+    assert regen.__schema_kind__ == "Renamed"
+
+
+def test_synthesised_field_is_required_no_default() -> None:
+    # the spec carries no defaults; every reconstructed field is required.
+    regen = _roundtrip(Optionals)
+    for spec in regen.__field_specs__.values():
+        assert spec.is_required
+
+
+# ---------------------------------------------------------------------------
+# closed sum sorts: TaggedUnion fields
+# ---------------------------------------------------------------------------
+
+
+class Kind(dx.TaggedUnion, discriminator="kind"):
+    """Two-variant discriminated union used as a field type."""
+
+
+class IntKind(Kind):
+    kind: Literal["int"]
+    value: int
+
+
+class StrKind(Kind):
+    kind: Literal["str"]
+    text: str
+
+
+class HasUnion(dx.Model):
+    """A model whose field is a TaggedUnion, alongside a scalar."""
+
+    head: Kind
+    note: str = ""
+
+
+class One(dx.TaggedUnion, discriminator="tag"):
+    """Single-variant union."""
+
+
+class OnlyVariant(One):
+    tag: Literal["only"]
+
+
+class HoldsOne(dx.Model):
+    x: One
+
+
+class Many(dx.TaggedUnion, discriminator="t"):
+    """Four-variant union exercising constructor order."""
+
+
+class VariantA(Many):
+    t: Literal["a"]
+
+
+class VariantB(Many):
+    t: Literal["b"]
+
+
+class VariantC(Many):
+    t: Literal["c"]
+
+
+class VariantD(Many):
+    t: Literal["d"]
+
+
+class HoldsMany(dx.Model):
+    m: Many
+
+
+class Sig(dx.TaggedUnion, discriminator="code"):
+    """Union whose discriminator pins integer literals."""
+
+
+class CodeOne(Sig):
+    code: Literal[1]
+
+
+class CodeTwo(Sig):
+    code: Literal[2]
+
+
+class HoldsSig(dx.Model):
+    s: Sig
+
+
+def _union_annotation(model: type[dx.Model], field: str) -> type[dx.TaggedUnion]:
+    """Return a field's annotation, narrowed to a TaggedUnion subclass."""
+    annotation = model.__field_specs__[field].annotation
+    assert isinstance(annotation, type)
+    assert issubclass(annotation, dx.TaggedUnion)
+    return annotation
+
+
+def _closed_list(spec: object, sort_name: str) -> list[str]:
+    """Pull a closed sum sort's ``Closed`` constructor list from a spec."""
+    spec_dict = cast("dict[str, list[dict[str, object]]]", spec)
+    sort = next(s for s in spec_dict["sorts"] if s["name"] == sort_name)
+    closure = cast("dict[str, list[str]]", sort["closure"])
+    return closure["Closed"]
+
+
+def test_tagged_union_field_spec_roundtrip() -> None:
+    # the gap closed: a TaggedUnion-bearing model's forward spec round-trips
+    # through the inbound synthesiser at the theory-spec level.
+    regen = model_from_spec(build_theory_spec(HasUnion))
+    assert build_theory_spec(regen) == build_theory_spec(HasUnion)
+
+
+def test_tagged_union_field_is_a_union_root() -> None:
+    regen = model_from_spec(build_theory_spec(HasUnion))
+    head_type = _union_annotation(regen, "head")
+    assert head_type.__discriminator__ == "kind"
+    # the union sort name is preserved (the forward path names it after the
+    # union class), and both variants register under their discriminator
+    assert head_type.__name__ == "Kind"
+    assert set(head_type.__variants__) == {"int", "str"}
+
+
+def test_tagged_union_variant_names_preserved() -> None:
+    regen = model_from_spec(build_theory_spec(HasUnion))
+    head_type = _union_annotation(regen, "head")
+    variant_names = {v.__name__ for v in head_type.__variants__.values()}
+    assert variant_names == {"IntKind", "StrKind"}
+
+
+def test_tagged_union_constructor_ops_not_treated_as_fields() -> None:
+    # the per-variant constructor ops (Kind_int, Kind_str) precede the field
+    # accessors in the ops list; they must not become fields of the model.
+    regen = model_from_spec(build_theory_spec(HasUnion))
+    assert set(regen.__field_specs__) == {"head", "note"}
+
+
+def test_tagged_union_single_variant_roundtrip() -> None:
+    regen = model_from_spec(build_theory_spec(HoldsOne))
+    assert build_theory_spec(regen) == build_theory_spec(HoldsOne)
+
+
+def test_tagged_union_many_variants_preserve_order() -> None:
+    orig = build_theory_spec(HoldsMany)
+    regen = model_from_spec(orig)
+    got = build_theory_spec(regen)
+    assert got == orig
+    # constructor order is preserved (Closed list order is significant)
+    assert _closed_list(got, "Many") == ["Many_a", "Many_b", "Many_c", "Many_d"]
+
+
+def test_tagged_union_field_used_twice_shares_one_sort() -> None:
+    class TwoFields(dx.Model):
+        first: Kind
+        second: Kind
+
+    orig = build_theory_spec(TwoFields)
+    regen = model_from_spec(orig)
+    assert build_theory_spec(regen) == orig
+    # only one Kind sort is emitted even though two fields use it
+    got = cast("dict[str, list[dict[str, object]]]", build_theory_spec(regen))
+    kind_sorts = [s for s in got["sorts"] if s["name"] == "Kind"]
+    assert len(kind_sorts) == 1
+
+
+def test_tagged_union_non_string_discriminator_value_collapses_to_str() -> None:
+    # a Literal[int] discriminator produces constructor names like Sig_1;
+    # the synthesiser rebuilds the value as the string "1". The constructor
+    # name round-trips, so the spec is preserved even though the Python
+    # discriminator value type (int) is not.
+    orig = build_theory_spec(HoldsSig)
+    regen = model_from_spec(orig)
+    assert build_theory_spec(regen) == orig
+    regen_union = _union_annotation(regen, "s")
+    # rebuilt discriminator values are strings
+    assert set(regen_union.__variants__) == {"1", "2"}
+
+
+def test_tagged_union_variant_registered_for_cross_reference() -> None:
+    # a variant payload sort is registered, so another model's Ref to it
+    # resolves to the same synthesised class object.
+    registry: dict[str, type[dx.Model]] = {}
+    model_from_spec(build_theory_spec(HasUnion), registry=registry)
+    assert "IntKind" in registry
+    assert "Kind" in registry
+    assert issubclass(registry["IntKind"], registry["Kind"])
+
+
+# ---------------------------------------------------------------------------
+# closed sum sorts: Model-ref recursive aliases
+# ---------------------------------------------------------------------------
+
+
+class AliasLeaf(dx.Model):
+    """Model arm of a recursive alias."""
+
+    v: str
+
+
+type _Tree = str | int | AliasLeaf | tuple["_Tree", ...] | dict[str, "_Tree"]
+type _P = str | AliasLeaf | tuple["_P", ...]
+type _D = int | AliasLeaf | dict[str, "_D"] | list["_D"]
+
+
+class HasAlias(dx.Model):
+    """A model whose field is a Model-ref recursive alias."""
+
+    body: _Tree
+
+
+class HoldsP(dx.Model):
+    p: _P
+
+
+class HoldsD(dx.Model):
+    d: _D
+
+
+def test_recursive_alias_field_spec_roundtrip() -> None:
+    regen = models_from_specs(
+        [build_theory_spec(AliasLeaf), build_theory_spec(HasAlias)]
+    )
+    assert build_theory_spec(regen["HasAlias"]) == build_theory_spec(HasAlias)
+
+
+def test_recursive_alias_resolves_model_arm_from_registry() -> None:
+    # AliasLeaf is passed first; the alias arm resolves to the real class.
+    regen = models_from_specs(
+        [build_theory_spec(AliasLeaf), build_theory_spec(HasAlias)]
+    )
+    assert "AliasLeaf" in regen
+    # the alias arm constructor input names the real arm model's sort
+    spec = cast(
+        "dict[str, list[dict[str, object]]]", build_theory_spec(regen["HasAlias"])
+    )
+    op = next(o for o in spec["ops"] if o["name"] == "_Tree_aliasleaf")
+    inputs = cast("list[list[str]]", op["inputs"])
+    assert inputs[0][1] == "AliasLeaf"
+
+
+def test_recursive_alias_arm_model_stubbed_when_absent() -> None:
+    # synthesising HasAlias alone (no AliasLeaf spec) still round-trips: the
+    # arm model is stood up as a fieldless stub named after the arm sort.
+    regen = model_from_spec(build_theory_spec(HasAlias))
+    assert build_theory_spec(regen) == build_theory_spec(HasAlias)
+
+
+def test_recursive_alias_only_primitives_and_one_model() -> None:
+    regen = models_from_specs([build_theory_spec(AliasLeaf), build_theory_spec(HoldsP)])
+    assert build_theory_spec(regen["HoldsP"]) == build_theory_spec(HoldsP)
+
+
+def test_recursive_alias_dict_and_list_arms() -> None:
+    regen = models_from_specs([build_theory_spec(AliasLeaf), build_theory_spec(HoldsD)])
+    assert build_theory_spec(regen["HoldsD"]) == build_theory_spec(HoldsD)
+
+
+def test_recursive_alias_field_is_a_sum_translation() -> None:
+    regen = model_from_spec(build_theory_spec(HasAlias))
+    # the rebuilt body field classifies back to a sum (closed sum sort),
+    # not an edge or scalar
+    body_spec = regen.__field_specs__["body"]
+    assert body_spec.translation.inner_kind == "sum"
+
+
+# ---------------------------------------------------------------------------
+# closed sum sorts: forward references, cycles, multi-model graphs
+# ---------------------------------------------------------------------------
+
+
+class Pointer(dx.Model):
+    """Holds a Ref to a union variant defined by HasUnion's synthesis."""
+
+    id: str
+    to: dx.Ref[IntKind]
+
+
+def test_recursive_alias_arm_resolves_in_reverse_order() -> None:
+    # HasAlias passed BEFORE AliasLeaf: the topo sort orders the arm model
+    # first, so the arm still resolves and the spec round-trips.
+    regen = models_from_specs(
+        [build_theory_spec(HasAlias), build_theory_spec(AliasLeaf)]
+    )
+    assert build_theory_spec(regen["HasAlias"]) == build_theory_spec(HasAlias)
+    assert "AliasLeaf" in regen
+
+
+def test_union_variant_referenced_by_edge_elsewhere() -> None:
+    # a separate model holds a Ref to a union variant; both resolve through
+    # the shared registry to the same class object.
+    regen = models_from_specs([build_theory_spec(HasUnion), build_theory_spec(Pointer)])
+    assert build_theory_spec(regen["Pointer"]) == build_theory_spec(Pointer)
+    # the edge target is the variant class registered by the union synthesis
+    spec = cast(
+        "dict[str, list[dict[str, object]]]", build_theory_spec(regen["Pointer"])
+    )
+    op = next(o for o in spec["ops"] if o["name"] == "to")
+    assert op["output"] == "IntKind"
+
+
+def test_multi_model_graph_with_union_and_alias() -> None:
+    # a graph mixing a TaggedUnion field, a recursive alias field, edges,
+    # and a shared leaf round-trips as a whole.
+    specs = [
+        build_theory_spec(AliasLeaf),
+        build_theory_spec(HasUnion),
+        build_theory_spec(HasAlias),
+        build_theory_spec(RefTarget),
+        build_theory_spec(RefHolder),
+    ]
+    regen = models_from_specs(specs)
+    assert build_theory_spec(regen["HasUnion"]) == build_theory_spec(HasUnion)
+    assert build_theory_spec(regen["HasAlias"]) == build_theory_spec(HasAlias)
+    assert build_theory_spec(regen["RefHolder"]) == build_theory_spec(RefHolder)
+
+
+# ---------------------------------------------------------------------------
+# closed sum sorts: error paths and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_discriminator_dropped_by_theory_raises() -> None:
+    # mimics the panproto.Theory path: a closed sum sort whose arms are all
+    # Model sorts (no value/container helper) and whose discriminator key
+    # was dropped. Without the discriminator the union cannot be rebuilt.
+    spec: dict[str, object] = {
+        "name": "Holder",
+        "extends": [],
+        "sorts": [
+            {"name": "Holder", "params": [], "kind": "Structural", "closure": "Open"},
+            {
+                "name": "U",
+                "params": [],
+                "kind": "Structural",
+                "closure": {"Closed": ["U_a", "U_b"]},
+            },
+        ],
+        "ops": [
+            {"name": "U_a", "inputs": [["v", "VariantA", "No"]], "output": "U"},
+            {"name": "U_b", "inputs": [["v", "VariantB", "No"]], "output": "U"},
+            {"name": "f", "inputs": [["self", "Holder", "No"]], "output": "U"},
+        ],
+        "eqs": [],
+        "directed_eqs": [],
+        "policies": [],
+    }
+    with pytest.raises(NotImplementedError, match="discriminator"):
+        model_from_spec(spec)
+
+
+def test_non_identifier_sort_name_rejected() -> None:
+    # a closed sum sort whose name is not a valid identifier cannot be
+    # rebuilt (the alias reconstructor would interpolate it into a `type`
+    # statement); reject it cleanly.
+    spec: dict[str, object] = {
+        "name": "Bad",
+        "extends": [],
+        "sorts": [
+            {"name": "Bad", "params": [], "kind": "Structural", "closure": "Open"},
+            {
+                "name": "not an ident",
+                "params": [],
+                "kind": "Structural",
+                "closure": {"Closed": ["not an ident_str"]},
+            },
+        ],
+        "ops": [
+            {
+                "name": "not an ident_str",
+                "inputs": [["v", "not an ident__str_value", "No"]],
+                "output": "not an ident",
+            },
+            {"name": "f", "inputs": [["self", "Bad", "No"]], "output": "not an ident"},
+        ],
+        "eqs": [],
+        "directed_eqs": [],
+        "policies": [],
+    }
+    with pytest.raises(ValueError, match="identifier"):
+        model_from_spec(spec)
+
+
+def test_model_from_theory_recovers_recursive_alias() -> None:
+    # the panproto.Theory path preserves alias sums (no discriminator key
+    # needed): a recursive alias round-trips through a real panproto.Theory.
+    pytest.importorskip("panproto")
+    from didactic.theory._theory import build_theory
+
+    registry: dict[str, type[dx.Model]] = {}
+    model_from_theory(build_theory(AliasLeaf), registry=registry)
+    regen = model_from_theory(build_theory(HasAlias), registry=registry)
+    assert build_theory_spec(regen) == build_theory_spec(HasAlias)
+
+
+def test_model_from_theory_tagged_union_raises_helpful() -> None:
+    # the panproto.Theory path drops the discriminator key, so a TaggedUnion
+    # field cannot be recovered through a Theory; the error points to the
+    # spec-dict path.
+    pytest.importorskip("panproto")
+    from didactic.theory._theory import build_theory
+
+    with pytest.raises(NotImplementedError, match="build_theory_spec"):
+        model_from_theory(build_theory(HasUnion))
+
+
+# ---------------------------------------------------------------------------
+# panproto.Theory path (needs the panproto runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_model_from_theory_roundtrip() -> None:
+    panproto = pytest.importorskip("panproto")
+    from didactic.theory._theory import build_theory
+
+    theory = build_theory(Scalars)
+    assert isinstance(theory, panproto.Theory)
+    regen = model_from_theory(theory)
+    assert build_theory_spec(regen) == build_theory_spec(Scalars)
+    assert set(regen.__field_specs__) == set(Scalars.__field_specs__)
+
+
+def test_model_from_theory_ref_edge() -> None:
+    pytest.importorskip("panproto")
+    from didactic.theory._theory import build_theory
+
+    registry: dict[str, type[dx.Model]] = {}
+    model_from_theory(build_theory(RefTarget), registry=registry)
+    regen = model_from_theory(build_theory(RefHolder), registry=registry)
+    assert build_theory_spec(regen) == build_theory_spec(RefHolder)


### PR DESCRIPTION
## Summary

Closes #45. The inbound synthesiser (`didactic.synthesis`) reconstructed scalar and edge fields but raised `NotImplementedError` on closed sum sorts. It now inverts both shapes the forward path emits, so a `dx.Model` carrying a `TaggedUnion` field or a Model-ref recursive alias round-trips through the synthesiser at the Theory-spec level.

## Motivation

The motivating downstream is **lairs**, which generates all its models from the union-heavy Layers lexicons. Until closed sum sorts round-trip through the inbound synthesiser, union fields (`anchor`, `objectRef`, the 7-kind annotation model) cannot be generated cleanly. This was the single `xfail` in the synthesis suite.

## Changes

- `packages/didactic/src/didactic/synthesis/_synthesis.py`
  - **TaggedUnion** (sum sort with a `discriminator` key): rebuild the root via `types.new_class(..., {"discriminator": d})` and one variant subclass per constructor, keyed by the discriminator value recovered from the constructor name `<Union>_<value>`. Variant payload fields are absent from the parent spec, so each variant carries only its discriminator field — enough for the parent's forward spec to round-trip.
  - **Model-ref recursive alias** (sum sort without a discriminator): read the constructor arms (primitive value helpers `<alias>__<tag>_value`, container helpers `<alias>__list_value`/`__dict_value`, and Model-sort inputs) and rebuild an equivalent self-referential `type` alias. Container element types collapse to a string helper on the forward path, so the rebuilt alias references itself in its container arms — reproducing the spec exactly while making it self-referential (the shape `classify` requires for the Model-ref path).
  - Variant and arm Model payloads resolve through the shared `registry` (an edge elsewhere binds the same class object); `models_from_specs` orders sum-arm dependencies ahead of dependents so a forward-referenced arm resolves to the real class, not a fieldless stub.
  - `model_from_theory` recovers aliases but raises a clear, actionable `NotImplementedError` on a discriminator-bearing sum sort, because a `panproto.Theory` drops the didactic-private `discriminator` key (verified: it is not part of the GAT theory vocabulary). The `build_theory_spec` dict path recovers it fully.
  - Interpolated sort names are identifier-checked before reaching the `type` statement.
- `packages/didactic/tests/test_synthesis.py` — the `xfail` is flipped to a real round-trip assertion; 36 tests total cover both sum shapes, constructor ordering, non-string discriminator collapse, registry cross-references, reverse-order/forward-reference resolution, a mixed multi-model graph, and the error paths.
- `docs/reference/model-synthesis.md` (new) + nav/index wiring; `CHANGELOG.md`.

## Scope note: upstream limitations, not worked around

While addressing this I traced the synthesiser's three documented lossiness limitations (scalar value kinds collapsing to `str`; `Ref` indistinguishable from `Embed`; per-field defaults/metadata absent) to panproto's GAT theory vocabulary: `Operation` is `{name, inputs, output}` with no containment marker or metadata slot, and `ValueKind` has no temporal/decimal/uuid variant. Resolving them would mean either smuggling didactic-private data through spec keys panproto ignores (a workaround) or new upstream vocabulary. Per maintainer direction I filed **panproto/panproto#190** for the intended representation and did **not** work around them here. Closed sum sorts, by contrast, are fully panproto-native (`SortClosure::Closed` + constructor ops), so #45 has no upstream dependency.

## Tests

36 synthesis tests (all new/flipped pass); full suite 679 passed. The decisive contract is `build_theory_spec(M) == build_theory_spec(model_from_spec(build_theory_spec(M)))` for TaggedUnion-bearing and recursive-alias-bearing models.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`

## Compatibility

- **Backwards-compatible addition** — closes a gap that previously raised `NotImplementedError`. New behaviour for inputs that used to be rejected; no existing behaviour changes. The `didactic.synthesis` public surface (`model_from_spec`, `models_from_specs`, `model_from_theory`) was already exported.

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[Unreleased]` (Added + a Notes block on the upstream-tracked limitations).

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

Closes #45. Refs panproto/panproto#190 (the GAT-vocabulary gaps behind the synthesiser's remaining lossiness).