### PR TITLE
chore: bump panproto to 0.53.0 (v0.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-06-16
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.52.1`` to ``0.53.0``.
+  The release adds a Python entry point for lexicon parsing
+  (``parse_atproto_lexicon`` / ``parse_schema_document`` /
+  ``Schema.from_atproto_lexicon``) and the Schema-to-Theory bridge
+  (``theory_of`` / ``Schema.theory``), and bumps its build to pyo3
+  0.29 for two ``RUSTSEC`` advisories. The GAT theory vocabulary
+  (``ValueKind`` / ``Operation`` / ``Sort``) is unchanged, so
+  didactic's forward and inbound theory paths, including closed-sum-sort
+  synthesis, are unaffected.
+
 ## [0.7.5] - 2026-06-16
 
 ### Added

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -110,6 +110,6 @@ Prints didactic's version followed by panproto's:
 
 ```bash
 didactic version
-# didactic 0.7.5
-# panproto 0.52.1
+# didactic 0.7.6
+# panproto 0.53.0
 ```

--- a/docs/project/stability.md
+++ b/docs/project/stability.md
@@ -40,7 +40,7 @@ each is documented in the [Changelog](changelog.md).
 
 ## panproto compatibility
 
-didactic pins panproto via a `>=` floor (currently `panproto>=0.52.1`).
+didactic pins panproto via a `>=` floor (currently `panproto>=0.53.0`).
 panproto's wire format may change between minor releases; didactic
 absorbs the difference internally so `import didactic` keeps working
 across panproto upgrades within the supported range.

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.5"
+version = "0.7.6"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.5"
+version = "0.7.6"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.5"
+version = "0.7.6"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.5"
+version = "0.7.6"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.52.1",
+    "panproto>=0.53.0",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -79,7 +79,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import Repository
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,12 +117,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.52.1" },
+    { name = "panproto", specifier = ">=0.53.0" },
 ]
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.52.1"
+version = "0.53.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d7/0fb6daf8704a7a2c5a14f265b3cde0380ac8290a925ad0e6c91d395d14e4/panproto-0.52.1-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60e6c22ead425e2177a780da7c8e29e884f2d2e8fae38422e6609030c521e873", size = 11795582, upload-time = "2026-06-09T19:25:38.104Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/97/d5ea226a50e197f9993149437dba76bb64e8e72760d70c08a0a446d29128/panproto-0.52.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:142500138cedcdd89927e1c9a693c3ce8a11f3995078831f37da927fd3fb4c05", size = 11536805, upload-time = "2026-06-09T19:25:41.375Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b8/1daf3c6e350bac1f8053db1d683f81e05ab03ade834d9b308f52ad1d602c/panproto-0.52.1-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2308fb27e6459e22a881d551dd3ce3c730f4c4e408ea0f2a695026889f1a747e", size = 12081852, upload-time = "2026-06-09T19:25:44.087Z" },
-    { url = "https://files.pythonhosted.org/packages/95/6a/b1da1fb53b69c10e299bbe119a3829348d3e7a6a26f7caa9fe0431e7272c/panproto-0.52.1-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f19783031776973d4a267d0cf0cc2f52eca1d89c85a7faa837460c691545f161", size = 12672689, upload-time = "2026-06-09T19:25:47.123Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/38/2bfa2e645f6b0172537b4b0d3b330c30587cf2ae42eaae30b472baeca697/panproto-0.52.1-cp313-abi3-win_amd64.whl", hash = "sha256:2ebbf3732100a7e17855828159269985c4471c0ff92ba827e20694e6fe16e271", size = 11747817, upload-time = "2026-06-09T19:25:50.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0a/57581dc8a7cdfaf11ab6a186c700e690134ca6eca355408cdae32d26acc7/panproto-0.53.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5cf1db85b3124060b263e1893df38d4fca835fbda1f69328f58574ceff73b501", size = 11846214, upload-time = "2026-06-16T14:05:54.174Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b2/af276378bcb76647d962e1c19ed94b481ba1262f7a026b350e612000b41f/panproto-0.53.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:418ca97f0e824c9092405eaf58c5c819c203bbe0eec721d6ea0c484a8a26b674", size = 11570050, upload-time = "2026-06-16T14:05:56.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e4/caa5ecbe6bebd03cf5b89c6ef886c41135d5c70205c6c6174ac5d176c98f/panproto-0.53.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d482776e7b38c0e8a543f6e65b241589c52a57abe059d46ab401fb6969dbd9fb", size = 12130326, upload-time = "2026-06-16T14:05:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ff/bcb215c5e1263326232742fde827837df4e6d696b61d50a3f449eefd9a0a/panproto-0.53.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b665dbaf75fa0fce795845bee2b3dfa223aad5e49a211a4e20f2e87b47e607f", size = 12729432, upload-time = "2026-06-16T14:06:01.257Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5c/5c1e4d35b2d428429d8836eb185c5d98d1db68d5c520209dbab403b440e9/panproto-0.53.0-cp313-abi3-win_amd64.whl", hash = "sha256:992634c51d7458e1964a7428e86fda21761424afde3b25d9238bfd417f3b7e5c", size = 11809776, upload-time = "2026-06-16T14:06:03.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Raises the panproto floor `0.52.1 → 0.53.0` and releases didactic v0.7.6. Mechanical percolation: no didactic source changes, just the pin, lock, version strings, and docs.

## Motivation

panproto 0.53.0 (panproto/panproto#191) lands the Python entry points the lairs → didactic → Layers pipeline needs — `parse_atproto_lexicon` / `parse_schema_document` / `Schema.from_atproto_lexicon` and the Schema→Theory bridge `theory_of` / `Schema.theory` — and bumps its build to pyo3 0.29 for two RUSTSEC advisories (`PyList`/`PyTuple` OOB read; missing `Sync` bound). It also records panproto's design answer to didactic's #190: refined scalars, Ref-vs-Embed, defaults/metadata, and containers all live at the **Schema** layer (constraints + `Edge.kind`), not the GAT theory.

## Changes

- `packages/didactic/pyproject.toml` — `panproto>=0.53.0`; all four distributions and sibling `__version__` strings bumped to 0.7.6.
- `uv.lock` refreshed to 0.53.0; `docs/guide/cli.md` `version` example and `docs/project/stability.md` pin updated.
- `CHANGELOG.md` — `[0.7.6] - 2026-06-16`.

## Why no source changes

I verified panproto 0.53.0 makes **zero changes to core `panproto-gat`** (`ValueKind` / `Operation` / `Sort` untouched), so didactic's forward and inbound theory paths — including the closed-sum-sort synthesis shipped in 0.7.5 — are unaffected. The new SDK surface is purely additive and pyo3 0.29 is internal to the wheel build. The full suite passes against the new wheel with no edits, and pyright strict (with `reportUnnecessaryCast`) stays at 0 errors, confirming no didactic cast became redundant under the resynced stubs.

## Tests

Full suite: 679 passed against panproto 0.53.0. All four distributions build at 0.7.6.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`
- [x] `uv build` for all four distributions

## Compatibility

- **No user-visible change** — dependency floor bump and version/docs only; no public API change.

## Changelog

- [x] Added a `CHANGELOG.md` entry (`[0.7.6]`).

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

The new panproto SDK surface answers panproto/panproto#190 (reconstruct field types from the Schema layer); exposing it in didactic's synthesiser is a tracked follow-up, intentionally not part of this floor bump.