### PR TITLE
Expose tag management on the public Repository (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-06-16
+
+### Added
+
+- ``Repository`` exposes tag management: ``create_tag(name, target, *,
+  force=False)`` for a lightweight tag, ``create_annotated_tag(name,
+  target, *, message, tagger)`` for an annotated-tag object, and
+  ``delete_tag(name)``. The three are thin pass-throughs to the
+  underlying panproto handle, mirroring how ``commit``,
+  ``create_branch``, and ``list_tags`` are already wrapped, so a
+  downstream that tags a revision through the documented surface no
+  longer has to reach the private inner handle. ([#49])
+
+[#49]: https://github.com/panproto/didactic/issues/49
+
 ## [0.7.6] - 2026-06-16
 
 ### Changed

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.6"
+version = "0.7.7"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.6"
+version = "0.7.7"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.6"
+version = "0.7.7"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.6"
+version = "0.7.7"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/vcs/_repo.py
+++ b/packages/didactic/src/didactic/vcs/_repo.py
@@ -12,8 +12,8 @@ Surface
 The wrapper covers initialisation, staging (either a panproto
 ``Schema`` or a [Model][didactic.api.Model] subclass), committing, the
 read-only introspection accessors (``head``, ``log``, ``working_dir``,
-branch listing), and ref / branch operations. Staging a Model class
-synthesises a single-vertex schema via
+branch listing), and ref / branch / tag operations. Staging a Model
+class synthesises a single-vertex schema via
 ``panproto.Protocol.from_theories`` over the Model's Theory.
 
 Notes
@@ -287,6 +287,96 @@ class Repository:
     def checkout_branch(self, name: str) -> None:
         """Switch HEAD to branch ``name``."""
         self._inner.checkout_branch(name)
+
+    # tags ----------------------------------------------------------
+
+    def create_tag(self, name: str, target: str, *, force: bool = False) -> None:
+        """Create a lightweight tag ``name`` pointing at ``target``.
+
+        A lightweight tag is a named pointer to a commit, carrying no
+        message or tagger. Use
+        [create_annotated_tag][didactic.api.Repository.create_annotated_tag]
+        for a tag object that records who tagged what, when, and why.
+
+        Parameters
+        ----------
+        name
+            The tag name.
+        target
+            The commit id to tag, as returned by
+            [commit][didactic.api.Repository.commit],
+            [head][didactic.api.Repository.head], or
+            [resolve_ref][didactic.api.Repository.resolve_ref].
+        force
+            If ``True``, overwrite an existing tag of the same name.
+            Defaults to ``False``, under which an existing ``name``
+            is an error.
+
+        Raises
+        ------
+        panproto.VcsError
+            If a tag ``name`` already exists and ``force`` is ``False``.
+        """
+        if force:
+            self._inner.create_tag_force(name, target)
+        else:
+            self._inner.create_tag(name, target)
+
+    def create_annotated_tag(
+        self,
+        name: str,
+        target: str,
+        *,
+        message: str,
+        tagger: str,
+    ) -> None:
+        """Create an annotated tag ``name`` pointing at ``target``.
+
+        An annotated tag is a first-class object recording a tagger,
+        a timestamp, and a message, unlike a lightweight tag which is
+        only a named pointer. The tag ref resolves to the annotated-tag
+        object rather than to ``target`` directly; that object id is
+        available through
+        [list_tags][didactic.api.Repository.list_tags].
+
+        Parameters
+        ----------
+        name
+            The tag name.
+        target
+            The commit id to tag (see
+            [create_tag][didactic.api.Repository.create_tag] for the
+            accepted forms).
+        message
+            The tag message.
+        tagger
+            The tagger identity. Free-form string; the conventional
+            shape is ``"Name <email>"``.
+
+        Raises
+        ------
+        panproto.VcsError
+            If a tag ``name`` already exists or panproto rejects the
+            tag.
+        """
+        # positional call: panproto's runtime arg order is
+        # ``(name, commit_id, tagger, message)``.
+        self._inner.create_annotated_tag(name, target, tagger, message)
+
+    def delete_tag(self, name: str) -> None:
+        """Delete the tag ``name``.
+
+        Parameters
+        ----------
+        name
+            The tag to delete.
+
+        Raises
+        ------
+        panproto.VcsError
+            If no tag ``name`` exists.
+        """
+        self._inner.delete_tag(name)
 
     # representation ------------------------------------------------
 

--- a/packages/didactic/tests/test_repo.py
+++ b/packages/didactic/tests/test_repo.py
@@ -86,15 +86,18 @@ def test_fresh_repo_has_no_branches_or_tags(fresh_repo_path: Path) -> None:
 # -- staging and committing -------------------------------------------
 
 
-def _build_minimal_schema() -> panproto.Schema:
+def _build_minimal_schema(vertex: str = "ping") -> panproto.Schema:
     """Construct a minimal panproto schema for staging tests.
 
     A schema with no vertices is rejected by the validator, so we add
     a single ``string`` vertex to satisfy the protocol's edge rules.
+    Passing a distinct ``vertex`` name yields a schema that differs from
+    the default, which a second commit needs to avoid panproto's
+    ``"no changes detected"`` rejection.
     """
     proto = panproto.get_builtin_protocol("openapi")
     builder = proto.schema()
-    builder.vertex("ping", "string")
+    builder.vertex(vertex, "string")
     return builder.build()
 
 
@@ -137,6 +140,90 @@ def test_branch_creation_and_checkout(fresh_repo_path: Path) -> None:
 
     repo.checkout_branch("feature")
     assert repo.resolve_ref("HEAD") == cid
+
+
+# -- tags -------------------------------------------------------------
+
+
+def _committed_repo(path: Path) -> tuple[dx.Repository, str]:
+    """Initialise a repo with a single commit; return it and the commit id."""
+    repo = dx.Repository.init(path)
+    repo.add(_build_minimal_schema())
+    cid = repo.commit("first", author="Test <test@example.com>")
+    return repo, cid
+
+
+def test_create_tag_lists_the_tag(fresh_repo_path: Path) -> None:
+    repo, cid = _committed_repo(fresh_repo_path)
+
+    repo.create_tag("v1", cid)
+    tag_names = {name for name, _ in repo.list_tags()}
+    assert "v1" in tag_names
+    assert repo.resolve_ref("v1") == cid
+
+
+def test_create_tag_duplicate_raises(fresh_repo_path: Path) -> None:
+    repo, cid = _committed_repo(fresh_repo_path)
+    repo.create_tag("v1", cid)
+
+    with pytest.raises(panproto.VcsError):
+        repo.create_tag("v1", cid)
+
+
+def test_create_tag_force_overwrites(fresh_repo_path: Path) -> None:
+    """``force=True`` replaces an existing tag instead of raising."""
+    repo, cid = _committed_repo(fresh_repo_path)
+    repo.create_tag("v1", cid)
+
+    repo.add(_build_minimal_schema("pong"))
+    second = repo.commit("second", author="Test <test@example.com>")
+
+    repo.create_tag("v1", second, force=True)
+    assert repo.resolve_ref("v1") == second
+
+
+def test_create_annotated_tag_round_trips(fresh_repo_path: Path) -> None:
+    """An annotated tag records its tagger and message.
+
+    The wrapper does not expose reading annotated-tag objects, so the
+    round trip is checked through a separately opened panproto handle:
+    this confirms the wrapper forwards ``tagger`` and ``message`` in
+    panproto's expected order rather than transposed.
+    """
+    repo, cid = _committed_repo(fresh_repo_path)
+
+    repo.create_annotated_tag(
+        "v1",
+        cid,
+        message="release one",
+        tagger="Tagger <tag@example.com>",
+    )
+
+    tags = dict(repo.list_tags())
+    assert "v1" in tags
+    # the tag ref resolves to the annotated-tag object, not the commit
+    assert tags["v1"] != cid
+
+    inner = panproto.Repository.open(str(fresh_repo_path))
+    annotated = inner.read_annotated_tag(tags["v1"])
+    assert annotated["target"] == cid
+    assert annotated["message"] == "release one"
+    assert annotated["tagger"] == "Tagger <tag@example.com>"
+
+
+def test_delete_tag_removes_it(fresh_repo_path: Path) -> None:
+    repo, cid = _committed_repo(fresh_repo_path)
+    repo.create_tag("v1", cid)
+
+    repo.delete_tag("v1")
+    assert repo.list_tags() == []
+
+
+def test_delete_missing_tag_raises(fresh_repo_path: Path) -> None:
+    repo, _ = _committed_repo(fresh_repo_path)
+
+    with pytest.raises(panproto.VcsError):
+        repo.delete_tag("nope")
 
 
 def test_add_accepts_model_class(fresh_repo_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #49.

`didactic.api.Repository` wrapped `list_tags`/`resolve_ref` but offered no way to **create** a tag, forcing downstreams (lairs) to reach the private inner handle: `self.inner._inner.create_tag(...)  # noqa: SLF001`. This adds the missing pass-throughs:

- `create_tag(name, target, *, force=False)` — lightweight tag; `force=True` overwrites via panproto's `create_tag_force`.
- `create_annotated_tag(name, target, *, message, tagger)` — annotated-tag object.
- `delete_tag(name)`.

All three are thin pass-throughs to the inner panproto handle, mirroring how `commit`, `create_branch`, and `list_tags` are already wrapped. lairs can now drop its `_inner.create_tag(...)` reach and the `SLF001` suppression.

## Implementation notes

- `create_annotated_tag` returns `None` rather than the annotated-tag object id. panproto's type stub declares the binding `-> None` (and transposes its `message`/`author` parameter names relative to the runtime), so the wrapper forwards **positionally** in panproto's real order `(name, commit_id, tagger, message)` and does not surface the return. The annotated-tag object id remains discoverable through `list_tags()`. The stub bug is being reported upstream.

## Tests

Six new tests in `test_repo.py`: lightweight create + list, duplicate raises, `force=True` overwrite, annotated round-trip (verified through a separately-opened panproto handle to confirm `tagger`/`message` ordering), delete, and delete-missing raises.

## Checks

Local matrix all green: `ruff format --check`, `ruff check`, `pyright` (strict), `pytest` (685 passed), `mkdocs build --strict`.

## Versioning

Bumps all four distributions `0.7.6 → 0.7.7` (lockstep) and adds the CHANGELOG entry.

---

Note: the sibling issue #50 (read committed working-tree content at a revision) is **not** in this PR. It needs a non-mutating committed-content accessor that panproto does not yet expose; it is being raised upstream and held until panproto ships the primitive.