### PR TITLE
Expose committed-data reads at a revision; panproto 0.54.0 (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-06-17
+
+### Added
+
+- ``Repository.data_at(ref)`` reads the datasets committed at a
+  revision without touching HEAD or the working tree, returning one
+  ``CommittedDataset`` (``schema_id`` / ``data`` / ``record_count``)
+  per committed dataset. This is the data-side counterpart to
+  panproto's committed-schema lookup, so a downstream can reconstruct
+  the record set at an arbitrary revision (for example to diff two
+  revisions) without checking it out. ``CommittedDataset`` is exported
+  from ``didactic.api``. ([#50])
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.53.0`` to ``0.54.0``,
+  which adds the ``data_at`` committed-data accessor behind the new
+  ``Repository.data_at`` and corrects the ``create_annotated_tag``
+  binding stub (return type and ``message`` / ``author`` argument
+  order).
+- ``Repository.create_annotated_tag`` returns the created
+  annotated-tag object id (the id the tag ref resolves to). It
+  previously returned ``None`` to sidestep the panproto stub, now
+  fixed upstream.
+
+### Fixed
+
+- The runtime ``__version__`` constant in each distribution
+  (``didactic.api``, ``didactic.pydantic``, ``didactic.settings``,
+  ``didactic.fastapi``) is bumped in lockstep with the packaging
+  version; the four had drifted to ``0.7.6``. A ``test_version`` guard
+  now fails if a runtime constant and its packaged version diverge.
+
+[#50]: https://github.com/panproto/didactic/issues/50
+
 ## [0.7.7] - 2026-06-16
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,11 @@ import didactic.api as dx
 All four distributions are published to PyPI from a single tag push.
 
 1. Bump the version in every package's `pyproject.toml` to the same
-   value (the four distributions ship in lockstep).
+   value (the four distributions ship in lockstep), and the matching
+   runtime `__version__` constant in each distribution's top module
+   (`didactic.api`, `didactic.pydantic`, `didactic.settings`,
+   `didactic.fastapi`). `test_version` fails if the two fall out of
+   step.
 2. Update `CHANGELOG.md` with the new version and date.
 3. Commit the version bump on `main`.
 4. Tag the commit with `vX.Y.Z` and push:

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.7"
+version = "0.7.8"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.6"
+__version__ = "0.7.8"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.7"
+version = "0.7.8"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.6"
+__version__ = "0.7.8"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.7"
+version = "0.7.8"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.6"
+__version__ = "0.7.8"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.7"
+version = "0.7.8"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.53.0",
+    "panproto>=0.54.0",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -77,9 +77,9 @@ from didactic.synthesis._synthesis import (
 )
 from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
-from didactic.vcs._repo import Repository
+from didactic.vcs._repo import CommittedDataset, Repository
 
-__version__ = "0.7.6"
+__version__ = "0.7.8"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator
@@ -91,6 +91,7 @@ __all__ = [
     "Axiom",
     "Backref",
     "BaseModel",
+    "CommittedDataset",
     "Correspondence",
     "DependentLens",
     "Embed",

--- a/packages/didactic/src/didactic/vcs/__init__.py
+++ b/packages/didactic/src/didactic/vcs/__init__.py
@@ -1,9 +1,10 @@
 """Filesystem-backed VCS for panproto schemas, plus Backref resolution."""
 
 from didactic.vcs._backref import ModelPool, resolve_backrefs
-from didactic.vcs._repo import Repository
+from didactic.vcs._repo import CommittedDataset, Repository
 
 __all__ = [
+    "CommittedDataset",
     "ModelPool",
     "Repository",
     "resolve_backrefs",

--- a/packages/didactic/src/didactic/vcs/_repo.py
+++ b/packages/didactic/src/didactic/vcs/_repo.py
@@ -30,6 +30,7 @@ panproto.Repository : the wrapped runtime type.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -39,6 +40,32 @@ if TYPE_CHECKING:
 
     from didactic.models._model import Model
     from didactic.types._typing import JsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedDataset:
+    """A dataset as recorded at a committed revision.
+
+    Returned by [data_at][didactic.api.Repository.data_at], one per
+    dataset committed at the requested revision. The wrapper exposes a
+    typed value rather than panproto's raw mapping so the public surface
+    does not leak the binding's dict shape.
+
+    Parameters
+    ----------
+    schema_id
+        Object id of the schema the dataset was validated against when
+        it was committed.
+    data
+        The raw committed bytes, exactly as staged (typically
+        content-addressed JSON).
+    record_count
+        Number of records panproto counted in ``data`` at commit time.
+    """
+
+    schema_id: str
+    data: bytes
+    record_count: int
 
 
 class Repository:
@@ -221,6 +248,36 @@ class Repository:
             raise panproto.VcsError(msg)
         return result
 
+    def data_at(self, ref: str) -> list[CommittedDataset]:
+        """Read the datasets committed at ``ref``.
+
+        A read-only accessor for committed content: it resolves
+        ``ref``, loads the datasets recorded at that revision, and
+        returns their bytes, leaving HEAD and the working tree
+        untouched. This is the data-side counterpart to panproto's
+        committed-schema lookup, so a downstream can reconstruct the
+        record set at an arbitrary revision, for example to diff two
+        revisions, without checking it out.
+
+        Parameters
+        ----------
+        ref
+            A branch name, tag name, ``HEAD``, or commit id naming the
+            revision to read.
+
+        Returns
+        -------
+        list of CommittedDataset
+            One entry per dataset committed at ``ref``, in panproto's
+            recorded order. Empty when the revision committed no data.
+
+        Raises
+        ------
+        panproto.VcsError
+            If ``ref`` does not resolve to a revision.
+        """
+        return [_committed_dataset(ds) for ds in self._inner.data_at(ref)]
+
     # mutation ------------------------------------------------------
 
     def add(self, target: panproto.Schema | type) -> None:
@@ -329,15 +386,13 @@ class Repository:
         *,
         message: str,
         tagger: str,
-    ) -> None:
+    ) -> str:
         """Create an annotated tag ``name`` pointing at ``target``.
 
         An annotated tag is a first-class object recording a tagger,
         a timestamp, and a message, unlike a lightweight tag which is
         only a named pointer. The tag ref resolves to the annotated-tag
-        object rather than to ``target`` directly; that object id is
-        available through
-        [list_tags][didactic.api.Repository.list_tags].
+        object rather than to ``target`` directly.
 
         Parameters
         ----------
@@ -353,15 +408,19 @@ class Repository:
             The tagger identity. Free-form string; the conventional
             shape is ``"Name <email>"``.
 
+        Returns
+        -------
+        str
+            Object id of the created annotated-tag object, the id the
+            tag ref resolves to.
+
         Raises
         ------
         panproto.VcsError
             If a tag ``name`` already exists or panproto rejects the
             tag.
         """
-        # positional call: panproto's runtime arg order is
-        # ``(name, commit_id, tagger, message)``.
-        self._inner.create_annotated_tag(name, target, tagger, message)
+        return self._inner.create_annotated_tag(name, target, tagger, message)
 
     def delete_tag(self, name: str) -> None:
         """Delete the tag ``name``.
@@ -415,6 +474,27 @@ def schema_from_model(cls: type[Model]) -> panproto.Schema:
     return builder.build()
 
 
+def _committed_dataset(ds: dict[str, str | bytes | int]) -> CommittedDataset:
+    """Narrow one panproto dataset mapping to a ``CommittedDataset``.
+
+    panproto types each committed dataset as a mapping with union-typed
+    values; the keys carry fixed types, so each is narrowed at the
+    boundary.
+    """
+    schema_id = ds["schema_id"]
+    data = ds["data"]
+    record_count = ds["record_count"]
+    assert isinstance(schema_id, str)
+    assert isinstance(data, bytes)
+    assert isinstance(record_count, int)
+    return CommittedDataset(
+        schema_id=schema_id,
+        data=data,
+        record_count=record_count,
+    )
+
+
 __all__ = [
+    "CommittedDataset",
     "Repository",
 ]

--- a/packages/didactic/tests/test_repo.py
+++ b/packages/didactic/tests/test_repo.py
@@ -192,7 +192,7 @@ def test_create_annotated_tag_round_trips(fresh_repo_path: Path) -> None:
     """
     repo, cid = _committed_repo(fresh_repo_path)
 
-    repo.create_annotated_tag(
+    tag_id = repo.create_annotated_tag(
         "v1",
         cid,
         message="release one",
@@ -200,12 +200,12 @@ def test_create_annotated_tag_round_trips(fresh_repo_path: Path) -> None:
     )
 
     tags = dict(repo.list_tags())
-    assert "v1" in tags
-    # the tag ref resolves to the annotated-tag object, not the commit
-    assert tags["v1"] != cid
+    # the tag ref resolves to the returned annotated-tag object, not the commit
+    assert tags["v1"] == tag_id
+    assert tag_id != cid
 
     inner = panproto.Repository.open(str(fresh_repo_path))
-    annotated = inner.read_annotated_tag(tags["v1"])
+    annotated = inner.read_annotated_tag(tag_id)
     assert annotated["target"] == cid
     assert annotated["message"] == "release one"
     assert annotated["tagger"] == "Tagger <tag@example.com>"
@@ -224,6 +224,56 @@ def test_delete_missing_tag_raises(fresh_repo_path: Path) -> None:
 
     with pytest.raises(panproto.VcsError):
         repo.delete_tag("nope")
+
+
+# -- committed data ---------------------------------------------------
+
+
+_RECORDS = b'[{"id": "a"}, {"id": "b"}]'
+
+
+def _commit_schema_and_data(path: Path, records: bytes) -> str:
+    """Commit a schema plus a staged data file through a panproto handle.
+
+    The wrapper does not expose ``add_data``, so the producing side runs
+    on a directly opened panproto handle; the test then reads the result
+    back through the public ``data_at``.
+    """
+    inner = panproto.Repository.init(str(path))
+    inner.add(_build_minimal_schema())
+    data_file = path / "records.json"
+    data_file.write_bytes(records)
+    inner.add_data(str(data_file))
+    return inner.commit("schema+data", "Test <test@example.com>")
+
+
+def test_data_at_returns_committed_dataset(fresh_repo_path: Path) -> None:
+    cid = _commit_schema_and_data(fresh_repo_path, _RECORDS)
+
+    repo = dx.Repository.open(fresh_repo_path)
+    datasets = repo.data_at("HEAD")
+    assert len(datasets) == 1
+    (dataset,) = datasets
+    assert isinstance(dataset, dx.CommittedDataset)
+    assert dataset.data == _RECORDS
+    assert dataset.record_count == 2
+    assert dataset.schema_id  # a non-empty object id
+
+    # the same revision is readable by commit id and by branch name
+    assert repo.data_at(cid) == datasets
+    assert repo.data_at("main") == datasets
+
+
+def test_data_at_is_empty_without_committed_data(fresh_repo_path: Path) -> None:
+    """A revision that committed only a schema has no datasets."""
+    repo, cid = _committed_repo(fresh_repo_path)
+    assert repo.data_at(cid) == []
+
+
+def test_data_at_unknown_ref_raises(fresh_repo_path: Path) -> None:
+    repo, _ = _committed_repo(fresh_repo_path)
+    with pytest.raises(panproto.VcsError):
+        repo.data_at("nope")
 
 
 def test_add_accepts_model_class(fresh_repo_path: Path) -> None:

--- a/packages/didactic/tests/test_version.py
+++ b/packages/didactic/tests/test_version.py
@@ -1,0 +1,38 @@
+"""The runtime ``__version__`` of each distribution matches its metadata.
+
+Every distribution hand-maintains a module-level ``__version__`` next to
+the version in its ``pyproject.toml``. The four ship in lockstep, so a
+release that bumps the packaging version must bump the constant too.
+This guards the drift where the two fall out of step.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+import pytest
+
+import didactic.api
+import didactic.fastapi
+import didactic.pydantic
+import didactic.settings
+
+# (declared constant, distribution name) for every shipped package.
+_DECLARED_VERSIONS: list[tuple[str, str]] = [
+    (didactic.api.__version__, "didactic"),
+    (didactic.pydantic.__version__, "didactic-pydantic"),
+    (didactic.settings.__version__, "didactic-settings"),
+    (didactic.fastapi.__version__, "didactic-fastapi"),
+]
+
+
+@pytest.mark.parametrize(("declared", "distribution"), _DECLARED_VERSIONS)
+def test_runtime_version_matches_metadata(declared: str, distribution: str) -> None:
+    """The ``__version__`` constant equals the installed package version."""
+    assert declared == version(distribution)
+
+
+def test_all_distributions_share_one_version() -> None:
+    """The four distributions ship in lockstep at a single version."""
+    declared = {v for v, _ in _DECLARED_VERSIONS}
+    assert len(declared) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.6"
+version = "0.7.8"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,12 +117,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.53.0" },
+    { name = "panproto", specifier = ">=0.54.0" },
 ]
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.6"
+version = "0.7.8"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.6"
+version = "0.7.8"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.6"
+version = "0.7.8"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.53.0"
+version = "0.54.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/0a/57581dc8a7cdfaf11ab6a186c700e690134ca6eca355408cdae32d26acc7/panproto-0.53.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5cf1db85b3124060b263e1893df38d4fca835fbda1f69328f58574ceff73b501", size = 11846214, upload-time = "2026-06-16T14:05:54.174Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b2/af276378bcb76647d962e1c19ed94b481ba1262f7a026b350e612000b41f/panproto-0.53.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:418ca97f0e824c9092405eaf58c5c819c203bbe0eec721d6ea0c484a8a26b674", size = 11570050, upload-time = "2026-06-16T14:05:56.522Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e4/caa5ecbe6bebd03cf5b89c6ef886c41135d5c70205c6c6174ac5d176c98f/panproto-0.53.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d482776e7b38c0e8a543f6e65b241589c52a57abe059d46ab401fb6969dbd9fb", size = 12130326, upload-time = "2026-06-16T14:05:58.788Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ff/bcb215c5e1263326232742fde827837df4e6d696b61d50a3f449eefd9a0a/panproto-0.53.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b665dbaf75fa0fce795845bee2b3dfa223aad5e49a211a4e20f2e87b47e607f", size = 12729432, upload-time = "2026-06-16T14:06:01.257Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5c/5c1e4d35b2d428429d8836eb185c5d98d1db68d5c520209dbab403b440e9/panproto-0.53.0-cp313-abi3-win_amd64.whl", hash = "sha256:992634c51d7458e1964a7428e86fda21761424afde3b25d9238bfd417f3b7e5c", size = 11809776, upload-time = "2026-06-16T14:06:03.412Z" },
+    { url = "https://files.pythonhosted.org/packages/10/16/f2d714c4e722d042b3cbcc72f87f23de27a990d64551c4e977a96dc0dd11/panproto-0.54.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:63b81a578ba5f3efccf5dcd1cd4bcfa49955c4c37cf8e41dc194196485bf158c", size = 11853839, upload-time = "2026-06-17T05:34:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/50/944abacccfa0e24e82fbd112230071a09053fef6fdde5ecb8372ef8c4bdf/panproto-0.54.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:982b4e28588d5b34b1f4b66dd68afb85aed45e0d1aa8bfa756eff49cfa68cc74", size = 11583274, upload-time = "2026-06-17T05:34:59.444Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/04e600fd11733f010979cdd8530e283e279f08ce0f14c59189e38052405b/panproto-0.54.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b3efd13285caef2fc41ceb209346c279d14a292255f5a3112df7f5d21d5d109e", size = 12143989, upload-time = "2026-06-17T05:35:01.607Z" },
+    { url = "https://files.pythonhosted.org/packages/12/15/7102450ccf631a8a42c8fdba30b2984de9e781e434b29027b553a5d3b647/panproto-0.54.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d52a433110539a702a7996aefdcde3dd018c64408e58989ecb8c5536fc0e57b", size = 12742645, upload-time = "2026-06-17T05:35:03.883Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/55/928b8e5e3757d63b0202ba35bba71cca9fdb1dd68ea97775645c0838f2e0/panproto-0.54.0-cp313-abi3-win_amd64.whl", hash = "sha256:ceac0b0ec2d17712f99589ab5412ea12c10e8d3a6b3ed19c6d6914b3803a7d50", size = 11812686, upload-time = "2026-06-17T05:35:06.004Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #50. Unblocked by panproto **0.54.0**, which adds the `data_at` committed-data accessor (panproto/panproto#193) and fixes the `create_annotated_tag` stub (panproto/panproto#194).

### Added — `Repository.data_at` (#50)

`didactic.api.Repository` could read the committed *schema* (via panproto's `schema_at`) but had no way to read committed *data* at a revision, so lairs fell back to `diff_snapshots` snapshot-juggling. New:

```python
def data_at(self, ref: str) -> list[CommittedDataset]: ...
```

It resolves `ref` (branch / tag / `HEAD` / commit id), loads the datasets recorded at that revision, and returns them **without touching HEAD or the working tree** — the read-only, data-side counterpart to `schema_at`. Each `CommittedDataset` (new, exported from `didactic.api`) is a frozen dataclass `{schema_id: str, data: bytes, record_count: int}`, so the public surface stays typed instead of leaking panproto's union-valued dict.

Scope is deliberately the **read** accessor only: issue #50 flags broader instance/value versioning as "a maintainer decision rather than assuming," so this PR does not add a public `add_data` write path.

### Changed — panproto floor → 0.54.0

- Required for `data_at`.
- Now that 0.54.0 fixes the stub, `Repository.create_annotated_tag` returns the annotated-tag object id (`str`) instead of the `None` it returned in 0.7.7 to dodge the broken stub. Widening the return is non-breaking.

### Fixed — runtime `__version__` drift

The hand-maintained `__version__` constants (`didactic.api`, `didactic.pydantic`, `didactic.settings`, `didactic.fastapi`) had drifted to `0.7.6` — `dx.__version__` and `didactic --version` were misreporting. They're now bumped in lockstep with the packaging version, a new `test_version` guard fails on future divergence, and the release checklist in `CONTRIBUTING.md` calls them out.

## Tests

`test_repo.py`: `data_at` round-trip (bytes / record_count / schema_id, plus by-commit-id and by-branch), empty-when-no-data, unknown-ref raises; annotated-tag test now asserts the returned id. New `test_version.py` guards the four runtime constants against `importlib.metadata`.

## Checks

Local matrix all green: `ruff format --check`, `ruff check`, `pyright` (strict, against panproto 0.54.0), `pytest` (693 passed), `mkdocs build --strict`.

## Versioning

All four distributions `0.7.7 → 0.7.8` (pyproject + runtime constant), CHANGELOG updated.