### PR TITLE
ci: create GitHub Release from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-# Build and publish all four workspace distributions to PyPI on tag push.
+# Build and publish all four workspace distributions to PyPI on tag push,
+# then create the matching GitHub Release from the CHANGELOG section.
 #
 # Triggers:
 #   - push to a tag matching `v*` (e.g. `v0.1.0`, `v1.0.0rc1`)
@@ -124,3 +125,58 @@ jobs:
           packages-dir: dist/
           skip-existing: true
           attestations: true
+
+  github-release:
+    name: github release
+    needs: publish
+    runs-on: ubuntu-24.04
+    # only meaningful for tag pushes; a workflow_dispatch from a branch has
+    # no version tag to release.
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build release notes from CHANGELOG
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          # escape dots so the version matches literally, not as "any char"
+          escaped="${version//./\\.}"
+          awk -v ver="$escaped" '
+            $0 ~ "^## \\[" ver "\\]" { grab = 1; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ -s RELEASE_NOTES.md ]; then
+            echo "found CHANGELOG section for $version"
+          else
+            echo "no CHANGELOG section for $version; falling back to generated notes"
+          fi
+
+      - name: create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists; nothing to do"
+            exit 0
+          fi
+          version="${TAG#v}"
+          args=(--title "$TAG" --verify-tag)
+          if [ -s RELEASE_NOTES.md ]; then
+            args+=(--notes-file RELEASE_NOTES.md)
+          else
+            args+=(--generate-notes)
+          fi
+          # mark X.Y.Z as the latest release; anything with a suffix
+          # (rc, dev, ...) is a prerelease and must not become "Latest".
+          if printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            args+=(--latest)
+          else
+            args+=(--prerelease --latest=false)
+          fi
+          gh release create "$TAG" "${args[@]}"


### PR DESCRIPTION
## Summary

The `Release` workflow built + published all four distributions to PyPI on a `v*` tag push, but **never created a GitHub Release** — that step was manual and got missed for v0.7.2, v0.7.7, and v0.7.8 (created by hand after the fact).

This adds a `github-release` job to `release.yml` that closes the gap.

## Behaviour

- **Runs after `publish`** (`needs: publish`), so a Release only appears once PyPI publishing succeeds; transitively gated on `verify` (lint/pyright/pytest/docs).
- **Notes from the CHANGELOG**: extracts the section for the pushed tag's version (`## [X.Y.Z]` up to the next `## [`) into the Release body, matching the existing hand-written Release style.
- **Prerelease aware**: a clean `X.Y.Z` is marked `--latest`; anything with a suffix (`rc`, `dev`, ...) is `--prerelease` and kept off "Latest".
- **Resilient**: falls back to `--generate-notes` if no CHANGELOG section is found (so a publish is never left without a Release), and **idempotent** — skips cleanly if the Release already exists (safe for `workflow_dispatch` re-runs).
- **Scoped permissions**: job-level `contents: write` (workflow default stays `contents: read`); guarded by `if: github.ref_type == 'tag'`.

## Validation

`actionlint` (with embedded shellcheck) passes clean. The CHANGELOG extraction and prerelease detection were exercised locally against the real `CHANGELOG.md` for v0.7.7 / v0.7.8 and against `1.0.0rc1` / `1.2.3-dev`.

No version bump or CHANGELOG entry: this is CI infra and takes effect on the next tag push.