### PR TITLE
Expose committed-data write (add_data) on Repository (#54 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-17
+
+### Added
+
+- ``Repository.add_data(path)`` stages a data file for the next commit,
+  the write-side counterpart to ``data_at``. It binds the file to the
+  staged schema, or to HEAD's schema when none is staged, and the
+  committed bytes are then readable at that revision through
+  ``data_at``. A downstream that versions record values can stage and
+  read them entirely through the documented surface instead of reaching
+  the inner panproto handle. ([#54])
+
+[#54]: https://github.com/panproto/didactic/issues/54
+
 ## [0.7.8] - 2026-06-17
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.7.8"
+version = "0.8.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.7.8"
+__version__ = "0.8.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.7.8"
+version = "0.8.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.7.8"
+__version__ = "0.8.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.7.8"
+version = "0.8.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.7.8"
+__version__ = "0.8.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.7.8"
+version = "0.8.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -79,7 +79,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import CommittedDataset, Repository
 
-__version__ = "0.7.8"
+__version__ = "0.8.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/vcs/_repo.py
+++ b/packages/didactic/src/didactic/vcs/_repo.py
@@ -305,6 +305,38 @@ class Repository:
         # ``Schema`` arm of the union is left.
         self._inner.add(cast("panproto.Schema", target))
 
+    def add_data(self, path: str | PathLike[str]) -> None:
+        """Stage a data file for the next commit.
+
+        Reads the file at ``path`` and stages its contents as a dataset
+        bound to the staged schema, or to HEAD's schema when no schema
+        is staged. The staged data is flushed by the next
+        [commit][didactic.api.Repository.commit] and is then readable at
+        that revision through
+        [data_at][didactic.api.Repository.data_at]. This is the
+        write-side counterpart to ``data_at``.
+
+        Parameters
+        ----------
+        path
+            Filesystem path to the data file to stage. The file is read
+            immediately and its contents are captured into the
+            repository's object store.
+
+        Notes
+        -----
+        Staging is additive: like [add][didactic.api.Repository.add],
+        repeated calls accumulate in the index until a commit flushes
+        it.
+
+        Raises
+        ------
+        panproto.VcsError
+            If no schema is staged and the repository has no commits
+            yet, so the dataset has no schema to bind to.
+        """
+        self._inner.add_data(str(path))
+
     def commit(
         self,
         message: str,

--- a/packages/didactic/tests/test_repo.py
+++ b/packages/didactic/tests/test_repo.py
@@ -233,18 +233,13 @@ _RECORDS = b'[{"id": "a"}, {"id": "b"}]'
 
 
 def _commit_schema_and_data(path: Path, records: bytes) -> str:
-    """Commit a schema plus a staged data file through a panproto handle.
-
-    The wrapper does not expose ``add_data``, so the producing side runs
-    on a directly opened panproto handle; the test then reads the result
-    back through the public ``data_at``.
-    """
-    inner = panproto.Repository.init(str(path))
-    inner.add(_build_minimal_schema())
+    """Commit a schema plus a staged data file through the public surface."""
+    repo = dx.Repository.init(path)
+    repo.add(_build_minimal_schema())
     data_file = path / "records.json"
     data_file.write_bytes(records)
-    inner.add_data(str(data_file))
-    return inner.commit("schema+data", "Test <test@example.com>")
+    repo.add_data(data_file)
+    return repo.commit("schema+data", author="Test <test@example.com>")
 
 
 def test_data_at_returns_committed_dataset(fresh_repo_path: Path) -> None:
@@ -262,6 +257,32 @@ def test_data_at_returns_committed_dataset(fresh_repo_path: Path) -> None:
     # the same revision is readable by commit id and by branch name
     assert repo.data_at(cid) == datasets
     assert repo.data_at("main") == datasets
+
+
+def test_add_data_stages_then_round_trips(fresh_repo_path: Path) -> None:
+    """``add_data`` stages a file that a commit then exposes via ``data_at``."""
+    repo = dx.Repository.init(fresh_repo_path)
+    repo.add(_build_minimal_schema())
+    data_file = fresh_repo_path / "records.json"
+    data_file.write_bytes(_RECORDS)
+
+    repo.add_data(data_file)
+    assert repo.has_staged() is True
+
+    repo.commit("schema+data", author="Test <test@example.com>")
+    (dataset,) = repo.data_at("HEAD")
+    assert dataset.data == _RECORDS
+    assert dataset.record_count == 2
+
+
+def test_add_data_without_schema_context_raises(fresh_repo_path: Path) -> None:
+    """Staging data needs a staged schema or a commit to bind to."""
+    repo = dx.Repository.init(fresh_repo_path)
+    data_file = fresh_repo_path / "records.json"
+    data_file.write_bytes(_RECORDS)
+
+    with pytest.raises(panproto.VcsError):
+        repo.add_data(data_file)
 
 
 def test_data_at_is_empty_without_committed_data(fresh_repo_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.7.8"
+version = "0.8.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -122,7 +122,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.7.8"
+version = "0.8.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.7.8"
+version = "0.8.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.7.8"
+version = "0.8.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Addresses **item 1** of #54.

`data_at` (read) was public, but the write — `add_data` — lived only on the inner `panproto.Repository`, so didactic's own test and lairs (`store/repository.py:save`) reached `self.inner._inner.add_data(...)  # noqa: SLF001`. This adds the public mirror:

```python
def add_data(self, path: str | PathLike[str]) -> None: ...
```

It stages a data file against the staged schema (or HEAD's schema when none is staged); the committed bytes are then readable at that revision via `data_at`. A downstream can now stage **and** read record values entirely through the documented surface, dropping the private reach — the same encapsulation win #51 gave tags. The data round-trip test now produces through the public `add_data` instead of a directly opened panproto handle.

This is the write-side I deferred in #50 pending a maintainer decision; #54 is that decision.

## Tests

New: `test_add_data_stages_then_round_trips` (init → add schema → add_data → `has_staged` → commit → `data_at`, all public) and `test_add_data_without_schema_context_raises` (no schema/HEAD → `VcsError`). The existing `_commit_schema_and_data` helper now uses the public `add_data`.

## Checks

Local matrix green: `ruff format --check`, `ruff check`, `pyright` (strict, panproto 0.54.0), `pytest` (695 passed), `mkdocs build --strict`.

## Versioning

New public API → **minor** bump `0.7.8 → 0.8.0` (first release under the true-SemVer policy), pyproject + runtime `__version__` across all four distributions, CHANGELOG updated.

---

The other two items of #54 are **not** in this PR — they need panproto changes (being filed upstream):
- **#54.2** (per-record key on `CommittedDataset`): the committed `DataSetObject` carries no key; the staged `source_path` is dropped at commit. panproto must persist an identifier before didactic can surface it.
- **#54.3** (data-only commit rejected): `has_staged()` counts staged data but `commit` requires a staged schema — a panproto contradiction.