### PR TITLE
Per-dataset key on committed data; panproto 0.56.0 (closes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-17
+
+### Added
+
+- ``CommittedDataset`` carries a ``key``: the identifier recorded for
+  the dataset, surfaced by ``data_at``. ``Repository.add_data`` takes an
+  optional ``key`` so a downstream that versions one record per dataset
+  can tag each with its own identifier (for example an AT-URI) and map a
+  committed dataset back to it; when omitted the key defaults to the
+  source path. This completes the committed-data round trip and lets a
+  downstream build a per-record, revision-to-revision diff from
+  ``data_at`` alone. ([#54])
+
+### Changed
+
+- Minimum ``panproto`` version raised from ``0.54.0`` to ``0.56.0``,
+  which records the per-dataset key behind ``add_data`` / ``data_at``
+  and lets a commit carry staged data forward without a schema change
+  (a data-only commit no longer raises ``nothing staged`` while
+  ``has_staged`` reports data staged).
+
+[#54]: https://github.com/panproto/didactic/issues/54
+
 ## [0.8.0] - 2026-06-17
 
 ### Added

--- a/docs/reference/repository.md
+++ b/docs/reference/repository.md
@@ -1,3 +1,5 @@
 # Repository
 
 ::: didactic.api.Repository
+
+::: didactic.api.CommittedDataset

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.8.0"
+version = "0.9.0"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.8.0"
+version = "0.9.0"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.8.0"
+version = "0.9.0"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.8.0"
+version = "0.9.0"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "panproto>=0.54.0",
+    "panproto>=0.56.0",
     "annotated-types>=0.7",
 ]
 

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -79,7 +79,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import CommittedDataset, Repository
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/vcs/_repo.py
+++ b/packages/didactic/src/didactic/vcs/_repo.py
@@ -61,11 +61,18 @@ class CommittedDataset:
         content-addressed JSON).
     record_count
         Number of records panproto counted in ``data`` at commit time.
+    key
+        Identifier recorded for the dataset: the key passed to
+        [add_data][didactic.api.Repository.add_data], or the source
+        path when none was given. A downstream that versions one record
+        per dataset uses this to map a committed dataset back to its own
+        key. ``None`` only if panproto recorded no identifier.
     """
 
     schema_id: str
     data: bytes
     record_count: int
+    key: str | None = None
 
 
 class Repository:
@@ -305,7 +312,7 @@ class Repository:
         # ``Schema`` arm of the union is left.
         self._inner.add(cast("panproto.Schema", target))
 
-    def add_data(self, path: str | PathLike[str]) -> None:
+    def add_data(self, path: str | PathLike[str], *, key: str | None = None) -> None:
         """Stage a data file for the next commit.
 
         Reads the file at ``path`` and stages its contents as a dataset
@@ -322,6 +329,13 @@ class Repository:
             Filesystem path to the data file to stage. The file is read
             immediately and its contents are captured into the
             repository's object store.
+        key
+            Identifier to record for the dataset, surfaced as
+            [CommittedDataset.key][didactic.api.CommittedDataset]. A
+            downstream that versions one record per dataset passes its
+            own key (for example an AT-URI) so it can map the committed
+            dataset back. When omitted, the dataset's key defaults to
+            ``path``.
 
         Notes
         -----
@@ -335,7 +349,7 @@ class Repository:
             If no schema is staged and the repository has no commits
             yet, so the dataset has no schema to bind to.
         """
-        self._inner.add_data(str(path))
+        self._inner.add_data(str(path), key)
 
     def commit(
         self,
@@ -506,7 +520,7 @@ def schema_from_model(cls: type[Model]) -> panproto.Schema:
     return builder.build()
 
 
-def _committed_dataset(ds: dict[str, str | bytes | int]) -> CommittedDataset:
+def _committed_dataset(ds: dict[str, str | bytes | int | None]) -> CommittedDataset:
     """Narrow one panproto dataset mapping to a ``CommittedDataset``.
 
     panproto types each committed dataset as a mapping with union-typed
@@ -516,13 +530,16 @@ def _committed_dataset(ds: dict[str, str | bytes | int]) -> CommittedDataset:
     schema_id = ds["schema_id"]
     data = ds["data"]
     record_count = ds["record_count"]
+    key = ds["key"]
     assert isinstance(schema_id, str)
     assert isinstance(data, bytes)
     assert isinstance(record_count, int)
+    assert key is None or isinstance(key, str)
     return CommittedDataset(
         schema_id=schema_id,
         data=data,
         record_count=record_count,
+        key=key,
     )
 
 

--- a/packages/didactic/tests/test_repo.py
+++ b/packages/didactic/tests/test_repo.py
@@ -285,6 +285,59 @@ def test_add_data_without_schema_context_raises(fresh_repo_path: Path) -> None:
         repo.add_data(data_file)
 
 
+def test_add_data_records_explicit_key(fresh_repo_path: Path) -> None:
+    """A key passed to ``add_data`` is surfaced on the committed dataset."""
+    repo = dx.Repository.init(fresh_repo_path)
+    repo.add(_build_minimal_schema())
+    data_file = fresh_repo_path / "records.json"
+    data_file.write_bytes(_RECORDS)
+    repo.add_data(data_file, key="at://did:plc:abc/app.bsky.feed.post/1")
+    repo.commit("schema+data", author="Test <test@example.com>")
+
+    (dataset,) = repo.data_at("HEAD")
+    assert dataset.key == "at://did:plc:abc/app.bsky.feed.post/1"
+
+
+def test_add_data_key_defaults_to_path(fresh_repo_path: Path) -> None:
+    """With no key, the dataset key falls back to the source path."""
+    repo = dx.Repository.init(fresh_repo_path)
+    repo.add(_build_minimal_schema())
+    data_file = fresh_repo_path / "records.json"
+    data_file.write_bytes(_RECORDS)
+    repo.add_data(data_file)
+    repo.commit("schema+data", author="Test <test@example.com>")
+
+    (dataset,) = repo.data_at("HEAD")
+    assert dataset.key == str(data_file)
+
+
+def test_data_only_commit_records_new_data(fresh_repo_path: Path) -> None:
+    """A data-only change commits and is readable at the new revision.
+
+    panproto lets a commit carry staged data forward without a schema
+    change, so ``has_staged`` and ``commit`` agree on staged data.
+    """
+    repo = dx.Repository.init(fresh_repo_path)
+    repo.add(_build_minimal_schema())
+    first_file = fresh_repo_path / "a.json"
+    first_file.write_bytes(b'[{"id": "a"}]')
+    repo.add_data(first_file, key="rec-a")
+    first = repo.commit("schema+data", author="Test <test@example.com>")
+
+    # stage only data, with no schema change
+    second_file = fresh_repo_path / "b.json"
+    second_file.write_bytes(b'[{"id": "b"}]')
+    repo.add_data(second_file, key="rec-b")
+    assert repo.has_staged() is True
+
+    second = repo.commit("data only", author="Test <test@example.com>")
+    assert second != first
+
+    (dataset,) = repo.data_at(second)
+    assert dataset.key == "rec-b"
+    assert dataset.data == b'[{"id": "b"}]'
+
+
 def test_data_at_is_empty_without_committed_data(fresh_repo_path: Path) -> None:
     """A revision that committed only a schema has no datasets."""
     repo, cid = _committed_repo(fresh_repo_path)

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -117,12 +117,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7" },
-    { name = "panproto", specifier = ">=0.54.0" },
+    { name = "panproto", specifier = ">=0.56.0" },
 ]
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },
@@ -555,14 +555,14 @@ wheels = [
 
 [[package]]
 name = "panproto"
-version = "0.54.0"
+version = "0.56.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/16/f2d714c4e722d042b3cbcc72f87f23de27a990d64551c4e977a96dc0dd11/panproto-0.54.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:63b81a578ba5f3efccf5dcd1cd4bcfa49955c4c37cf8e41dc194196485bf158c", size = 11853839, upload-time = "2026-06-17T05:34:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/50/944abacccfa0e24e82fbd112230071a09053fef6fdde5ecb8372ef8c4bdf/panproto-0.54.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:982b4e28588d5b34b1f4b66dd68afb85aed45e0d1aa8bfa756eff49cfa68cc74", size = 11583274, upload-time = "2026-06-17T05:34:59.444Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/0d/04e600fd11733f010979cdd8530e283e279f08ce0f14c59189e38052405b/panproto-0.54.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b3efd13285caef2fc41ceb209346c279d14a292255f5a3112df7f5d21d5d109e", size = 12143989, upload-time = "2026-06-17T05:35:01.607Z" },
-    { url = "https://files.pythonhosted.org/packages/12/15/7102450ccf631a8a42c8fdba30b2984de9e781e434b29027b553a5d3b647/panproto-0.54.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d52a433110539a702a7996aefdcde3dd018c64408e58989ecb8c5536fc0e57b", size = 12742645, upload-time = "2026-06-17T05:35:03.883Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/55/928b8e5e3757d63b0202ba35bba71cca9fdb1dd68ea97775645c0838f2e0/panproto-0.54.0-cp313-abi3-win_amd64.whl", hash = "sha256:ceac0b0ec2d17712f99589ab5412ea12c10e8d3a6b3ed19c6d6914b3803a7d50", size = 11812686, upload-time = "2026-06-17T05:35:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/54/8805d08478456d2a735e1b655f62e28a00f3448b2fe843e17d34a0b0b409/panproto-0.56.0-cp313-abi3-macosx_10_12_x86_64.whl", hash = "sha256:97bc980a79bcee6b0b2462de3c911e5dc445ae03b526686755464a6985a3ae22", size = 10510052, upload-time = "2026-06-17T17:08:08.442Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c4/62fe169cffc8167d4e9bfa1a86a9475e45e378131a9fd156f8705a0015ee/panproto-0.56.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:c20874c04409a5a5eeed3d23d5ee9321bdafb8c670591cf45232bfaedadcaa4e", size = 9902837, upload-time = "2026-06-17T17:08:11.645Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/4f/cbc5b6af69e60f7383923b48efb03f734c544eab98911acc400029c28fcd/panproto-0.56.0-cp313-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8aecc9a31dec120e0c726717e285a729302afe2fc732d26849dcb18d35f1b001", size = 9956556, upload-time = "2026-06-17T17:08:14.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/25ea821479f22a35a9ae025119f558e60d3703f1f23520402760aca280fa/panproto-0.56.0-cp313-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:004f00b2b7b735770bb351fd96c722ebad9c6601f58bd9d4bb5a083dc566b921", size = 10694185, upload-time = "2026-06-17T17:08:16.981Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f0/a9ac50829ca831699999c5833de41dc669162ce0cfa3660c040cc85386f7/panproto-0.56.0-cp313-abi3-win_amd64.whl", hash = "sha256:05048df0cb00e118f2ff014227c4aadb7eda55daf615ab3de3215dafce82e663", size = 11757785, upload-time = "2026-06-17T17:08:19.85Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Closes #54.** panproto **0.56.0** (panproto/panproto#197, #198) lands both remaining items, so this PR finishes the committed-data path.

### Added — per-record key (#54.2)
`CommittedDataset` now carries a `key`, and `Repository.add_data` takes an optional `key`:

```python
def add_data(self, path: str | PathLike[str], *, key: str | None = None) -> None: ...

@dataclass(frozen=True, slots=True)
class CommittedDataset:
    schema_id: str
    data: bytes
    record_count: int
    key: str | None = None
```

A downstream that versions one record per dataset passes its own key (e.g. an AT-URI); `data_at` returns it, so it can map a committed dataset back and build a per-record, revision-to-revision diff from `data_at` alone. When omitted, the key defaults to the source path.

### Fixed upstream — data-only commit (#54.3)
0.56.0 lets a commit carry staged data forward without a schema change, so `add_data` + `commit` with no schema change now succeeds and `has_staged()`/`commit` agree. didactic's pass-throughs need no change; a new test (`test_data_only_commit_records_new_data`) guards the behaviour end-to-end through the public surface.

### Changed
- panproto floor `0.54.0 → 0.56.0`.
- `CommittedDataset` is now rendered on the Repository reference page — it was exported from `didactic.api` since 0.7.8 but never documented (the missing anchor was what `mkdocs --strict` caught here).

## Tests
New: explicit-key round-trip, key-defaults-to-path, and the data-only commit. `pytest` 698 passed.

## Checks
Local matrix green: `ruff format --check`, `ruff check`, `pyright` (strict, panproto 0.56.0), `pytest`, `mkdocs build --strict`.

## Versioning
New public API → **minor** `0.8.0 → 0.9.0` (pyproject + runtime `__version__` across all four), CHANGELOG updated. Release will auto-create the GitHub Release from the CHANGELOG.