### PR TITLE
perf(models): make recursive TaggedUnion construction non-exponential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-18
+
+### Fixed
+
+- Constructing a nested recursive `TaggedUnion` value is now linear in
+  the number of nodes rather than exponential in nesting depth. A
+  sum-sort field keeps its variant's fully expanded wire JSON in
+  storage, so `model_dump` reads and parses that directly instead of
+  decoding it back to a `Model` and re-encoding it (a round trip that
+  re-walked the whole subtree at every enclosing level). The emitted
+  wire form is unchanged. ([#58])
+- `derived_field_names` is a pure function of the class, so it is
+  materialised once at class-creation time as `__derived_field_names__`
+  on the metaclass and read from there, rather than recomputed on every
+  `Model.__init__` and every `model_dump`. ([#59])
+
+[#58]: https://github.com/panproto/didactic/issues/58
+[#59]: https://github.com/panproto/didactic/issues/59
+
 ## [0.9.0] - 2026-06-17
 
 ### Added

--- a/packages/didactic-fastapi/pyproject.toml
+++ b/packages/didactic-fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-fastapi"
-version = "0.9.0"
+version = "0.9.1"
 description = "FastAPI integration for didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
+++ b/packages/didactic-fastapi/src/didactic/fastapi/__init__.py
@@ -23,7 +23,7 @@ from didactic.fastapi._adapter import (
     register_validation_handler,
 )
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-pydantic/pyproject.toml
+++ b/packages/didactic-pydantic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-pydantic"
-version = "0.9.0"
+version = "0.9.1"
 description = "Pydantic interop for didactic — adapters for incremental migration."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
+++ b/packages/didactic-pydantic/src/didactic/pydantic/__init__.py
@@ -45,7 +45,7 @@ Examples
 from didactic.pydantic._adapter import from_pydantic
 from didactic.pydantic._reverse import to_pydantic
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 __all__ = [
     "__version__",

--- a/packages/didactic-settings/pyproject.toml
+++ b/packages/didactic-settings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic-settings"
-version = "0.9.0"
+version = "0.9.1"
 description = "Typed application settings on top of didactic Models."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic-settings/src/didactic/settings/__init__.py
+++ b/packages/didactic-settings/src/didactic/settings/__init__.py
@@ -27,7 +27,7 @@ from didactic.settings._settings import (
     Settings,
 )
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 __all__ = [
     "CliSource",

--- a/packages/didactic/pyproject.toml
+++ b/packages/didactic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "didactic"
-version = "0.9.0"
+version = "0.9.1"
 description = "Pydantic-class API on top of panproto: GATs, lenses, and VCS."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/didactic/src/didactic/api.py
+++ b/packages/didactic/src/didactic/api.py
@@ -79,7 +79,7 @@ from didactic.types import _types_lib as types
 from didactic.vcs._backref import ModelPool, resolve_backrefs
 from didactic.vcs._repo import CommittedDataset, Repository
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 #: Conventional namespace for lens utilities (`dx.lens.identity(...)`,
 #: `dx.lens.Lens`, etc.). The ``lens`` name doubles as a decorator

--- a/packages/didactic/src/didactic/models/_meta.py
+++ b/packages/didactic/src/didactic/models/_meta.py
@@ -42,6 +42,7 @@ from typing import (
 
 from didactic.axioms._axioms import collect_class_axioms
 from didactic.fields._computed import computed_field_names
+from didactic.fields._derived import derived_field_names
 from didactic.fields._fields import (
     MISSING,
     Field,
@@ -380,6 +381,7 @@ class ModelMeta(type):
     __schema_kind__: str
     __model_config__: ModelConfig
     __computed_fields__: tuple[str, ...]
+    __derived_field_names__: tuple[str, ...]
     __class_axioms__: tuple[Axiom, ...]
     __field_validators__: dict[str, tuple[tuple[str, str], ...]]
     __model_validators__: tuple[str, ...]
@@ -431,6 +433,7 @@ class ModelMeta(type):
             cls.__schema_kind__ = name
             cls.__model_config__ = DEFAULT_CONFIG
             cls.__computed_fields__ = ()
+            cls.__derived_field_names__ = ()
             cls.__class_axioms__ = ()
             cls.__field_validators__ = {}
             cls.__model_validators__ = ()
@@ -440,6 +443,11 @@ class ModelMeta(type):
         cls.__model_config__ = mcs._resolve_config(cls, config_overrides)
         cls.__field_specs__ = ModelMeta.collect_field_specs(cls)
         cls.__computed_fields__ = computed_field_names(cls)
+        # ``derived_field_names`` is a pure function of the class (it walks
+        # the MRO for ``@derived``-marked properties), so materialise it once
+        # here rather than recomputing it on every ``Model.__init__`` and
+        # every ``model_dump``.
+        cls.__derived_field_names__ = derived_field_names(cls)
         cls.__class_axioms__ = collect_class_axioms(cls)
         cls.__field_validators__ = ModelMeta.collect_field_validators(cls)
         cls.__model_validators__ = ModelMeta.collect_model_validators(cls)

--- a/packages/didactic/src/didactic/models/_model.py
+++ b/packages/didactic/src/didactic/models/_model.py
@@ -222,9 +222,7 @@ class Model(metaclass=ModelMeta):
         # break model_validate(model_dump(...)) for any model with
         # computed fields.
         computed_names = cls.__computed_fields__
-        from didactic.fields._derived import derived_field_names  # noqa: PLC0415
-
-        derived_names = derived_field_names(cls)
+        derived_names = cls.__derived_field_names__
         # ``extra="ignore"`` silently drops unknown kwargs at construction.
         # ``with_()`` stays strict regardless: an unknown kwarg there is
         # always a programming error (see ``Model.with_``).
@@ -460,20 +458,36 @@ class Model(metaclass=ModelMeta):
                 if not exclude_none:
                     result[key] = None
                 continue
+            # Sum-sort fields carry their variant's fully expanded wire JSON
+            # in ``_storage`` already. Read and parse that directly instead
+            # of decoding the string back to a Model and re-encoding it. The
+            # decode + re-encode round trip re-walks the entire subtree at
+            # every enclosing level, so for a recursive TaggedUnion it is
+            # exponential in nesting depth; parsing storage is a single pass
+            # and yields the identical wire shape.
+            if spec.translation.inner_kind == "sum":
+                raw = cast("FieldValue", json.loads(self._storage.get(fname)))
+                if exclude_none and raw is None:
+                    continue
+                if exclude_defaults and not spec.is_required:
+                    default = spec.default
+                    default_wire = (
+                        cast("FieldValue", json.loads(default.model_dump_json()))
+                        if isinstance(default, Model)
+                        else default
+                    )
+                    if raw == default_wire:
+                        continue
+                key = spec.alias if by_alias and spec.alias else fname
+                result[key] = raw
+                continue
             value = spec.translation.decode(self._storage.get(fname))
             if exclude_none and value is None:
                 continue
             if exclude_defaults and not spec.is_required and value == spec.default:
                 continue
             key = spec.alias if by_alias and spec.alias else fname
-            # Sum-sort fields must run first: a sum field whose current
-            # value is a Model variant would otherwise be dumped as a
-            # plain Model below and lose its constructor tag.
-            if spec.translation.inner_kind == "sum":
-                result[key] = cast(
-                    "FieldValue", json.loads(spec.translation.encode(value))
-                )
-            elif isinstance(value, Model):
+            if isinstance(value, Model):
                 # Embed[T] fields: recurse into the sub-model
                 result[key] = value.model_dump(by_alias=by_alias)
             else:
@@ -493,10 +507,9 @@ class Model(metaclass=ModelMeta):
             else:
                 result[cname] = value
         # derived fields are computed once, cached, and dumped alongside
-        # regular fields. We import lazily to avoid an import cycle.
-        from didactic.fields._derived import derived_field_names  # noqa: PLC0415
-
-        for dname in derived_field_names(cls):
+        # regular fields. The name tuple is materialised on the class at
+        # creation time (see ``ModelMeta.__new__``).
+        for dname in cls.__derived_field_names__:
             if include is not None and dname not in include:
                 continue
             if exclude is not None and dname in exclude:

--- a/packages/didactic/tests/test_pydantic_parity.py
+++ b/packages/didactic/tests/test_pydantic_parity.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import didactic.api as dx
+from didactic.fields import _derived
+
+if TYPE_CHECKING:
+    import pytest
 
 # -- model_dump options ----------------------------------------------
 
@@ -132,3 +138,51 @@ def test_derived_round_trip_through_dump() -> None:
     back = Person.model_validate(payload)
     assert back.first == "Grace"
     assert back.display_name == "Grace Hopper"
+
+
+def test_derived_field_names_cached_on_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The derived-name tuple is materialised once per class, not per instance.
+
+    ``derived_field_names`` is a pure function of the class, so the
+    metaclass computes it at class-creation time and stores it as
+    ``__derived_field_names__``. ``Model.__init__`` and ``model_dump``
+    read that cached tuple; neither recomputes it, so constructing and
+    dumping never re-walk the MRO.
+    """
+
+    class Base(dx.Model):
+        first: str
+        last: str
+
+        @dx.derived
+        def full(self) -> str:
+            return f"{self.first} {self.last}"
+
+    class Sub(Base):
+        title: str
+
+        @dx.derived
+        def formal(self) -> str:
+            return f"{self.title} {self.full}"
+
+    assert Base.__derived_field_names__ == ("full",)
+    assert set(Sub.__derived_field_names__) == {"full", "formal"}
+
+    calls = 0
+    original = _derived.derived_field_names
+
+    def counting(cls: type) -> tuple[str, ...]:
+        nonlocal calls
+        calls += 1
+        return original(cls)
+
+    monkeypatch.setattr(_derived, "derived_field_names", counting)
+
+    for _ in range(100):
+        instance = Sub(first="Ada", last="Lovelace", title="Dr")
+        assert instance.model_dump()["formal"] == "Dr Ada Lovelace"
+
+    # construction + dump read the cached tuple; the walker never runs
+    assert calls == 0

--- a/packages/didactic/tests/test_tagged_union_recursive.py
+++ b/packages/didactic/tests/test_tagged_union_recursive.py
@@ -16,11 +16,14 @@ Pins two fixes:
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
 import didactic.api as dx
+
+if TYPE_CHECKING:
+    from didactic.types._typing import FieldValue, JsonValue
 
 
 class _N(dx.TaggedUnion, discriminator="kind"):
@@ -114,3 +117,49 @@ def test_dict_payload_for_directly_constructed_field() -> None:
     )
     assert isinstance(node.left, _Lit)
     assert node.left.value == 1
+
+
+def _build_chain(depth: int) -> _N:
+    node: _N = _Lit(kind="lit", value=0)
+    for _ in range(depth):
+        node = _BinOp(kind="binop", op="+", left=node, right=_Lit(kind="lit", value=1))
+    return node
+
+
+def test_recursive_construction_is_linear_not_exponential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Building a depth-``D`` recursive TaggedUnion runs ``2*D+1`` constructions.
+
+    A ``TaggedUnion``-typed field keeps its variant's fully expanded wire
+    JSON in ``_storage``. Dumping it previously decoded that string back to
+    a Model and re-encoded it, re-walking the whole subtree at every
+    enclosing level; that round trip made construction ``2**(D+1) - 1``
+    ``Model.__init__`` calls (exponential, eventually hanging).
+    ``model_dump`` now reads storage directly, so the count is exactly the
+    node count.
+    """
+    from didactic.models._model import Model
+
+    original_init = Model.__init__
+    calls = 0
+
+    def counting_init(self: Model, **kwargs: FieldValue | JsonValue) -> None:
+        nonlocal calls
+        calls += 1
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Model, "__init__", counting_init)
+
+    for depth in (4, 8, 12, 16):
+        calls = 0
+        _build_chain(depth)
+        # D BinOp nodes + (D + 1) Lit nodes, and no reconstruction beyond them
+        assert calls == 2 * depth + 1
+
+
+def test_recursive_dump_round_trips_at_depth() -> None:
+    """A deep chain dumps and reloads to the same wire JSON."""
+    node = _build_chain(24)
+    wire = node.model_dump_json()
+    assert _N.model_validate_json(wire).model_dump_json() == wire

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "didactic"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/didactic" }
 dependencies = [
     { name = "annotated-types" },
@@ -122,7 +122,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-fastapi"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/didactic-fastapi" }
 dependencies = [
     { name = "didactic" },
@@ -139,7 +139,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-pydantic"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/didactic-pydantic" }
 dependencies = [
     { name = "didactic" },
@@ -154,7 +154,7 @@ requires-dist = [
 
 [[package]]
 name = "didactic-settings"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/didactic-settings" }
 dependencies = [
     { name = "didactic" },


### PR DESCRIPTION
## Summary

Fix two construction-path defects in the Model / `TaggedUnion` machinery that surface when building deep recursive `TaggedUnion` values (an AST of `dx.TaggedUnion` nodes). `Closes #58` and `Closes #59`. The public API and the emitted wire form are unchanged; construction drops from exponential to linear.

## Motivation

Both surfaced from constructing deep recursive `TaggedUnion` trees bottom-up.

- **#58**: a value of nesting depth `D` triggered `2**(D+1) - 1` `Model.__init__` calls and eventually hung. A sum-sort field kept its variant's fully expanded wire JSON in storage, but `model_dump` decoded that back to a `Model` and re-encoded it, re-walking the whole subtree at every enclosing level.
- **#59**: `derived_field_names` is a pure function of the class, but it was recomputed on every `Model.__init__` and every `model_dump` (the single largest cost of constructing a Model with no derived fields).

## Changes

- `packages/didactic/src/didactic/models/_model.py` — `model_dump` reads and parses a sum-sort field's stored wire form directly instead of the decode-plus-encode round trip; `Model.__init__` and `model_dump` read a cached `__derived_field_names__` tuple.
- `packages/didactic/src/didactic/models/_meta.py` — `ModelMeta.__new__` materialises `__derived_field_names__` once per class at class-creation time.
- `packages/didactic/tests/test_tagged_union_recursive.py` — regression tests: construction is exactly linear in the node count (deterministic `__init__`-count assertion, not `2**(D+1)-1`), and a deep chain round-trips to identical wire JSON.
- `packages/didactic/tests/test_pydantic_parity.py` — regression test: the derived-name tuple is cached per class and never recomputed during construction or dump.
- `CHANGELOG.md`, and the `version` / `__version__` across the four distributions: `0.9.0 -> 0.9.1`.

## Tests

- `test_tagged_union_recursive.py`: `test_recursive_construction_is_linear_not_exponential` (patches `Model.__init__`, asserts the count is `2*D+1` at depths 4/8/12/16), `test_recursive_dump_round_trips_at_depth`.
- `test_pydantic_parity.py`: `test_derived_field_names_cached_on_class` (monkeypatches the walker, asserts zero calls across 100 constructions + dumps; checks inherited derived names).
- Full package suite: 638 passed.

## Local CI

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest -ra`
- [x] `uv run mkdocs build --strict`

## Compatibility

- **No user-visible change** — internal refactor, docs, tests, or CI. (A construction-path performance and correctness fix; the public API and the emitted wire form are byte-identical. Existing code keeps working, only faster.)

## Changelog

- [x] Added a `CHANGELOG.md` entry under `[Unreleased]` (cut to `[0.9.1]`).
- [ ] No changelog entry needed.

## Pyright suppressions

- [x] This PR does not introduce or modify any pyright suppression.

## Linked issues

- `Closes #58`
- `Closes #59`